### PR TITLE
ENH/TST/BUG: Add test model object

### DIFF
--- a/pysatModels/__init__.py
+++ b/pysatModels/__init__.py
@@ -18,8 +18,8 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from pysatModels import (utils)
-from pysatModels import (models)
+from pysatModels import utils
+from pysatModels import models
 
 # set the version
 here = os.path.abspath(os.path.dirname(__file__))

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -67,9 +67,9 @@ def load(fnames, tag=None, sat_id=None):
                               'longitude': longitude, 'altitude': altitude})
 
     slt = np.zeros([len(uts), len(longitude)])
-    for i in range(len(uts)):
-        for j in range(len(longitude)):
-            slt[i, j] = np.mod(uts[i]/3600.0 + longitude[j]/15.0, 24.0)
+    for i, ut in enumerate(uts):
+        for j, long in enumerate(longitude):
+            slt[i, j] = np.mod(ut/3600.0 + long/15.0, 24.0)
     data['slt'] = (('time', 'longtiude'), slt)
 
     # Fake 3D data consisting of ones everywhere

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+Produces fake instrument data for testing.
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+import numpy as np
+import pandas as pds
+import xarray as xr
+
+import pysat
+
+platform = 'pysat'
+name = 'testmodel'
+
+pandas_format = False
+_test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
+
+
+def init(self):
+    self.new_thing = True
+
+
+def load(fnames, tag=None, sat_id=None, malformed_index=False):
+    """ Loads the test files
+
+    Parameters
+    ----------
+    fnames : (list)
+        List of filenames
+    tag : (str or NoneType)
+        Instrument tag (accepts '')
+    sat_id : (str or NoneType)
+        Instrument satellite ID (accepts '' or a number (i.e., '10'), which
+        specifies the number of data points to include in the test instrument)
+    malformed_index : bool (False)
+        If True, the time index will be non-unique and non-monotonic.
+
+    Returns
+    -------
+    data : (xr.Dataset)
+        Testing data
+    meta : (pysat.Meta)
+        Metadataxs
+
+    """
+
+    # create an artifical model data set
+    parts = os.path.split(fnames[0])[-1].split('-')
+    yr = int(parts[0])
+    month = int(parts[1])
+    day = int(parts[2][0:2])
+    date = pysat.datetime(yr, month, day)
+
+    # Create one day of data at desired frequency
+    index = pds.date_range(start=date, end=date+pds.DateOffset(seconds=86399),
+                           freq='9000s')
+    # Allow numeric string to select first set of data
+    if sat_id.isnumeric() and (int(sat_id) < 86400):
+        index = index[0:int(sat_id)]
+
+    uts = index.hour*3600 + index.minute*60 + index.second
+
+    latitude = np.linspace(-50, 50, 101)
+    longitude = np.linspace(0, 360, 73)
+    altitude = np.linspace(300, 500, 41)
+    data = xr.Dataset({'uts': (('time'), index)},
+                      coords={'time': index, 'latitude': latitude,
+                              'longitude': longitude, 'altitude': altitude})
+
+    slt = np.zeros([len(uts), len(longitude)])
+    for i in range(len(uts)):
+        for j in range(len(longitude)):
+            slt[i, j] = np.mod(uts[i]/3600.0 + longitude[j]/15.0, 24.0)
+    data['slt'] = (('time', 'longtiude'), slt)
+
+    dummy1 = np.ones([len(uts), len(latitude), len(longitude)])
+    data['dummy1'] = (('time', 'latitude', 'longitude'), dummy1)
+
+    dummy2 = np.ones([len(uts), len(latitude), len(longitude), len(altitude)])
+    data['dummy2'] = (('time', 'latitude', 'longitude', 'altitude'), dummy2)
+
+    meta = pysat.Meta()
+
+    return data, meta
+
+
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
+               file_date_range=None):
+    """Produce a fake list of files spanning a year
+
+    Parameters
+    ----------
+    tag : (str)
+        pysat instrument tag (default=None)
+    sat_id : (str)
+        pysat satellite ID tag (default=None)
+    data_path : (str)
+        pysat data path (default=None)
+    format_str : (str)
+        file format string (default=None)
+    file_date_range : (pds.date_range)
+        File date range (default=None)
+
+    Returns
+    -------
+    Series of filenames indexed by file time
+
+    """
+
+    # Determine the appropriate date range for the fake files
+    if file_date_range is None:
+        start = _test_dates[''][''] - pds.DateOffset(years=1)
+        stop = _test_dates[''][''] + pds.DateOffset(years=2) \
+            - pds.DateOffset(days=1)
+        file_date_range = pds.date_range(start, stop)
+
+    index = file_date_range
+
+    # Create the list of fake filenames
+    names = [data_path + date.strftime('%Y-%m-%d') + '.nofile'
+             for date in index]
+
+    return pysat.Series(names, index=index)
+
+
+def download(date_array, tag, sat_id, data_path=None,
+             user=None, password=None):
+    """ Download routine, not used since files are created locally"""
+    pass

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -43,7 +43,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     data : (xr.Dataset)
         Testing data
     meta : (pysat.Meta)
-        Metadataxs
+        Metadata
 
     """
 
@@ -76,9 +76,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
             slt[i, j] = np.mod(uts[i]/3600.0 + longitude[j]/15.0, 24.0)
     data['slt'] = (('time', 'longtiude'), slt)
 
+    # Fake 3D data consisting of ones everywhere
     dummy1 = np.ones([len(uts), len(latitude), len(longitude)])
     data['dummy1'] = (('time', 'latitude', 'longitude'), dummy1)
 
+    # Fake 4D data consisting of ones everywhere
     dummy2 = np.ones([len(uts), len(latitude), len(longitude), len(altitude)])
     data['dummy2'] = (('time', 'latitude', 'longitude', 'altitude'), dummy2)
 

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -59,7 +59,7 @@ def load(fnames, tag=None, sat_id=None):
 
     uts = index.hour*3600 + index.minute*60 + index.second
 
-    latitude = np.linspace(-50, 50, 101)
+    latitude = np.linspace(-50, 50, 21)
     longitude = np.linspace(0, 360, 73)
     altitude = np.linspace(300, 500, 41)
     data = xr.Dataset({'uts': (('time'), index)},

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -72,12 +72,12 @@ def load(fnames, tag=None, sat_id=None):
             slt[i, j] = np.mod(ut/3600.0 + long/15.0, 24.0)
     data['slt'] = (('time', 'longtiude'), slt)
 
-    # Fake 3D data consisting of ones everywhere
-    dummy1 = np.ones([len(uts), len(latitude), len(longitude)])
+    # Fake 3D data consisting of values between 0 and 21 everywhere
+    dummy1 = np.mod(data['uts']*data['latitude']*data['longitude'], 21.0)
     data['dummy1'] = (('time', 'latitude', 'longitude'), dummy1)
 
-    # Fake 4D data consisting of ones everywhere
-    dummy2 = np.ones([len(uts), len(latitude), len(longitude), len(altitude)])
+    # Fake 4D data consisting of between 0 and 21 everywhere
+    dummy2 = np.mod(data['dummy1'] * data['altitude'], 21.0)
     data['dummy2'] = (('time', 'latitude', 'longitude', 'altitude'), dummy2)
 
     meta = pysat.Meta()

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -81,6 +81,26 @@ def load(fnames, tag=None, sat_id=None):
     data['dummy2'] = (('time', 'latitude', 'longitude', 'altitude'), dummy2)
 
     meta = pysat.Meta()
+    meta['uts'] = {'units': 's',
+                   'long_name': 'Universal Time',
+                   'custom': False}
+    meta['slt'] = {'units': 'hours',
+                   'long_name': 'Solar Local Time',
+                   'label': 'SLT',
+                   'axis': 'SLT',
+                   'desc': 'Solar Local Time',
+                   'value_min': 0.0,
+                   'value_max': 24.0,
+                   'notes': ('Solar Local Time is the local time (zenith '
+                             'angle of sun) of the given locaiton. Overhead '
+                             'noon, +/- 90 is 6, 18 SLT .'),
+                   'fill': np.nan,
+                   'scale': 'linear'}
+    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
+    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
+    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
+    meta['dummy1'] = {'units': '', 'long_name': 'dummy1'}
+    meta['dummy2'] = {'units': '', 'long_name': 'dummy2'}
 
     return data, meta
 

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -62,7 +62,7 @@ def load(fnames, tag=None, sat_id=None):
     latitude = np.linspace(-50, 50, 21)
     longitude = np.linspace(0, 360, 73)
     altitude = np.linspace(300, 500, 41)
-    data = xr.Dataset({'uts': (('time'), index)},
+    data = xr.Dataset({'uts': (('time'), uts)},
                       coords={'time': index, 'latitude': latitude,
                               'longitude': longitude, 'altitude': altitude})
 

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -56,9 +56,6 @@ def load(fnames, tag=None, sat_id=None):
     # Create one day of data at desired frequency
     index = pds.date_range(start=date, end=date+pds.DateOffset(seconds=86399),
                            freq='9000s')
-    # Allow numeric string to select first set of data
-    if sat_id.isnumeric() and (int(sat_id) < 86400):
-        index = index[0:int(sat_id)]
 
     uts = index.hour*3600 + index.minute*60 + index.second
 

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -5,8 +5,8 @@ Produces fake instrument data for testing.
 from __future__ import print_function
 from __future__ import absolute_import
 
-import os
 import numpy as np
+import os
 import pandas as pds
 import xarray as xr
 

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -55,7 +55,7 @@ def load(fnames, tag=None, sat_id=None):
 
     # Create one day of data at desired frequency
     index = pds.date_range(start=date, end=date+pds.DateOffset(seconds=86399),
-                           freq='9000s')
+                           freq='900s')
 
     uts = index.hour*3600 + index.minute*60 + index.second
 

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -23,7 +23,7 @@ def init(self):
     self.new_thing = True
 
 
-def load(fnames, tag=None, sat_id=None, malformed_index=False):
+def load(fnames, tag=None, sat_id=None):
     """ Loads the test files
 
     Parameters
@@ -35,8 +35,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     sat_id : (str or NoneType)
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
-    malformed_index : bool (False)
-        If True, the time index will be non-unique and non-monotonic.
+
 
     Returns
     -------

--- a/pysatModels/models/pysat_testmodel.py
+++ b/pysatModels/models/pysat_testmodel.py
@@ -69,11 +69,11 @@ def load(fnames, tag=None, sat_id=None):
     slt = np.zeros([len(uts), len(longitude)])
     for i, ut in enumerate(uts):
         for j, long in enumerate(longitude):
-            slt[i, j] = np.mod(ut/3600.0 + long/15.0, 24.0)
+            slt[i, j] = np.mod(ut / 3600.0 + long / 15.0, 24.0)
     data['slt'] = (('time', 'longtiude'), slt)
 
     # Fake 3D data consisting of values between 0 and 21 everywhere
-    dummy1 = np.mod(data['uts']*data['latitude']*data['longitude'], 21.0)
+    dummy1 = np.mod(data['uts'] * data['latitude'] * data['longitude'], 21.0)
     data['dummy1'] = (('time', 'latitude', 'longitude'), dummy1)
 
     # Fake 4D data consisting of between 0 and 21 everywhere
@@ -131,8 +131,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
     # Determine the appropriate date range for the fake files
     if file_date_range is None:
         start = _test_dates[''][''] - pds.DateOffset(years=1)
-        stop = _test_dates[''][''] + pds.DateOffset(years=2) \
-            - pds.DateOffset(days=1)
+        stop = (_test_dates[''][''] + pds.DateOffset(years=2)
+                - pds.DateOffset(days=1))
         file_date_range = pds.date_range(start, stop)
 
     index = file_date_range

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -8,6 +8,7 @@ import pytest
 import pysat
 
 import pysatModels.utils.extract as extract
+from pysatModels.models import pysat_testmodel
 
 
 @pytest.mark.skip("input requires a regular grid for the model")
@@ -47,11 +48,9 @@ class TestUtilsExtractModObs:
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.inst = pysat.Instrument(platform=str('pysat'),
-                                     name=str('testing'), sat_id='1',
+                                     name=str('testing'), sat_id='10',
                                      clean_level='clean')
-        self.model = pysat.Instrument(platform=str('pysat'),
-                                      name=str('testing2d_xarray'),
-                                      clean_level='clean')
+        self.model = pysat.Instrument(inst_module=pysat_testmodel)
         self.inst.load(yr=2009, doy=1)
         self.model.load(yr=2009, doy=1)
         self.input_args = [self.inst, self.model.data,

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -56,7 +56,7 @@ class TestUtilsExtractModObs:
         self.input_args = [self.inst, self.model.data,
                            ["longitude", "latitude", "slt"],
                            ["longitude", "latitude", "slt"],
-                           "uts", "time", ["deg", "deg", "h"]]
+                           "time", "time", ["deg", "deg", "h"]]
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""

--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -771,7 +771,7 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
                     if str(verr).find("requested xi is out of bounds") > 0:
                         # This is acceptable, pad the interpolated data with
                         # NaN
-                        ps_mod.logger.Warning(
+                        ps_mod.logger.warning(
                             "{:} for {:s} data at {:}".format(verr, mdat, xi))
                         yi = [np.nan]
                     else:


### PR DESCRIPTION
# Description

Closes #22, closes #24.

Adds `pysat_testmodel` object to models for use in unit tests.  Includes both 3D and 4D fake data variables in an xarray.Dataset.  Maintains 5 deg x 5 deg lat/long resolution, 5 km altitude resolution, 15 min temporal resolution.  Updates the test_extract routines to use this object for unit tests.

Also fixes two bugs:
- typo in logger.warning
- unit tests for extract require more than one data point in the pysat_testing object (documented in #22)

Minor style updates to be consistent with previous pulls.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested via pytest -vs

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
