### PR TITLE
TST/BUG: Use testmodel object, update to custom.attach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jobs:
     - python: 2.7
     - python: 3.6
     - python: 3.7
-    - python: 3.8
 
 services: xvfb
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ before_install:
   - pip install pandas
   - pip install xarray
   - pip install matplotlib
-  # Install pysatCDF and dump output
+# Travis CI currently not working with netCDF4 1.5.3
+  - pip install 'cftime==1.1.1'
+  - pip install 'netCDF4<1.5.3'
+# Install pysatCDF and dump output
   - pip install pysatCDF >/dev/null
   # Prepare pysat install from git
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 dist: xenial
 jobs:
   include:
-    - python: 2.7
     - python: 3.6
     - python: 3.7
 

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import pysat
+from pysat.instruments import pysat_testmodel
 
 import pysatModels.utils.extract as extract
 
@@ -47,17 +48,15 @@ class TestUtilsExtractModObs:
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.inst = pysat.Instrument(platform=str('pysat'),
-                                     name=str('testing'), sat_id='1',
+                                     name=str('testing'), sat_id='10',
                                      clean_level='clean')
-        self.model = pysat.Instrument(platform=str('pysat'),
-                                      name=str('testing2d_xarray'),
-                                      clean_level='clean')
+        self.model = pysat.Instrument(inst_module=pysat_testmodel)
         self.inst.load(yr=2009, doy=1)
         self.model.load(yr=2009, doy=1)
         self.input_args = [self.inst, self.model.data,
                            ["longitude", "latitude", "slt"],
                            ["longitude", "latitude", "slt"],
-                           "uts", "time", ["deg", "deg", "h"]]
+                           "time", "time", ["deg", "deg", "h"]]
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""

--- a/pysatModels/utils/match.py
+++ b/pysatModels/utils/match.py
@@ -224,9 +224,9 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs={},
 
             # Load the instrument data, if needed
             if inst.empty or inst.index[-1] < istart:
-                inst.custom.add(pysat.utils.coords.update_longitude, 'modify',
-                                low=lon_low, lon_name=inst_lon_name,
-                                high=lon_high)
+                inst.custom.attach(pysat.utils.coords.update_longitude,
+                                   'modify', low=lon_low,
+                                   lon_name=inst_lon_name, high=lon_high)
                 inst.load(date=istart)
 
             if not inst.empty and inst.index[0] >= istart:


### PR DESCRIPTION
# Description

Addresses #22 and #24.

- Uses the new `pysat_testmodel` object in test_utils_extract to more closely simulate how the code will be used.
- Updates custom.add to custom.attach in `collect_inst_model_pairs` to match pysat 3.0.0 syntax.
- Implements netcdf fixes in travis environment documented in pysat/pysat#401 and pysat/pysat#383.  These were keeping pysat from loading.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

Tested locally and on Travis CI using pytest.

**Test Configuration**:
* Mac OSX 10.15.4
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
