### PR TITLE
TST/BUG: remove unused test for match.collect_inst_model_pairs

### DIFF
--- a/pysatModels/tests/test_utils_match.py
+++ b/pysatModels/tests/test_utils_match.py
@@ -77,9 +77,7 @@ class TestUtilsMatchCollectInstModPairs:
         del self.input_args, self.required_kwargs, self.inst, self.model
 
     @pytest.mark.parametrize("del_key,err_msg",
-                             [("model_load_kwargs",
-                               "must provide a pysat.Instrument object"),
-                              ("inst_lon_name", "Need longitude name for inst"),
+                             [("inst_lon_name", "Need longitude name for inst"),
                               ("mod_lon_name", "Need longitude name for model"),
                               ("inst_name", "Must provide instrument location"),
                               ("mod_name", "Must provide the same number"),


### PR DESCRIPTION
# Description

Unit tests currently check for an error message if no model is supplied.  This error message should not be generated, so this test is removed.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

pytest -vs

**Test Configuration**:
* Mac OS X 10.15.4
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
