### PR TITLE
TST: test models with inherited unit tests from pysat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout download_flags
+  - git checkout develop-3
   - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   - cd ../pysatModels

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout develop-3
+  - git checkout download_tags
   - python setup.py install >/dev/null
   - cd ../pysatModels
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
-    # set up data directory
+  # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
   - git checkout download_flags

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - mkdir /home/travis/build/pysatData
   # install pysat
   - git checkout download_flags
-  - python setup.py install >/dev/null
+  - python setup.py install
   - cd ../pysatModels
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout download_tags
+  - git checkout download_flags
   - python setup.py install >/dev/null
   - cd ../pysatModels
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ before_install:
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
-  # set up data directory
-  - mkdir /home/travis/build/pysatData
   # install pysat
   - git checkout download_flags
   - python setup.py install >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
   # install pysat
   - git checkout download_flags
   - python setup.py install >/dev/null
+  - export PYTHONPATH=$PYTHONPATH:$(pwd)
   - cd ../pysatModels
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ before_install:
   - mkdir /home/travis/build/pysatData
   # install pysat
   - git checkout download_flags
-  - python setup.py install
+  - python setup.py install >/dev/null
+  - ls
   - cd ../pysatModels
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
   - cd ./pysat
+    # set up data directory
+  - mkdir /home/travis/build/pysatData
   # install pysat
   - git checkout download_flags
   - python setup.py install >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
   # install pysat
   - git checkout download_flags
   - python setup.py install >/dev/null
-  - ls
   - cd ../pysatModels
 
 install:

--- a/pysatModels/models/__init__.py
+++ b/pysatModels/models/__init__.py
@@ -15,3 +15,5 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from pysatModels.models import ucar_tiegcm
+
+__all__ = ['ucar_tiegcm']

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -48,7 +48,7 @@ sat_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported!
 # format is outer dictionary has sat_id as the key
 # each sat_id has a dictionary of test dates keyed by tag string
-_test_dates = {'': {'': pysat.datetime(2019, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 _test_download = {'': {'': False}}
 
 # specify using xarray (not using pandas)

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -47,7 +47,8 @@ sat_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported!
 # format is outer dictionary has sat_id as the key
 # each sat_id has a dictionary of test dates keyed by tag string
-test_dates = {'': {'': pysat.datetime(2019, 1, 1)}}
+_test_dates = {'': {'': pysat.datetime(2019, 1, 1)}}
+_test_download = {'': {'': False}}
 
 # specify using xarray (not using pandas)
 pandas_format = False

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 
 import pysatModels
 
+import pysat.tests
 import pysat.tests.test_instruments
 from pysat.tests.test_instruments import generate_instrument_list
 from pysat.tests.test_instruments import TestInstrumentsAll

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -14,6 +14,7 @@ InstClasses = [TestInstrumentsAll, TestInstrumentsDownload,
                TestInstrumentsNoDownload]
 
 for InstClass in InstClasses:
+    # Need to turn off __test__ so that tests are not run until modified
     InstClass.__test__ = False
     method_list = [func for func in dir(InstClass)
                    if callable(getattr(InstClass, func))]
@@ -23,7 +24,9 @@ for InstClass in InstClasses:
             Nargs =  len(getattr(InstClass, method).pytestmark)
             names = [getattr(InstClass, method).pytestmark[j].name
                      for j in range(0, Nargs)]
+            # Remove instruments imported from pysat
             getattr(InstClass, method).pytestmark.clear()
+            # Add instruments from pysatModels
             if InstClass == TestInstrumentsAll:
                 mark = pytest.mark.parametrize("name", instruments['names'])
                 getattr(InstClass, method).pytestmark.append(mark)

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -1,8 +1,8 @@
 import pytest
 
 import pysatModels
-from pysat.tests.instrument_tests import generate_instrument_list
-from pysat.tests.instrument_tests import InstTestClass
+from pysat.tests.instrument_test_class import generate_instrument_list
+from pysat.tests.instrument_test_class import InstTestClass
 
 instruments = generate_instrument_list(pysatModels.models.__all__,
                                        package='pysatModels.models')

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 
 import pysatModels
 
+import pysat.tests.test_instruments
 from pysat.tests.test_instruments import generate_instrument_list
 from pysat.tests.test_instruments import TestInstrumentsAll
 from pysat.tests.test_instruments import TestInstrumentsDownload

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -1,75 +1,34 @@
 import pytest
 
 import pysatModels
-
-from pysat.tests.test_instruments import generate_instrument_list
-from pysat.tests.test_instruments import TestInstrumentsAll
-from pysat.tests.test_instruments import TestInstrumentsDownload
-from pysat.tests.test_instruments import TestInstrumentsNoDownload
+from pysat.tests.instrument_tests import generate_instrument_list
+from pysat.tests.instrument_tests import InstTestClass
 
 instruments = generate_instrument_list(pysatModels.models.__all__,
                                        package='pysatModels.models')
 
-InstClasses = [TestInstrumentsAll, TestInstrumentsDownload,
-               TestInstrumentsNoDownload]
-
-for InstClass in InstClasses:
-    # Need to turn off __test__ so that tests are not run until modified
-    InstClass.__test__ = False
-    method_list = [func for func in dir(InstClass)
-                   if callable(getattr(InstClass, func))]
-    # Search tests for iteration via pytestmark, update instrument list
-    for method in method_list:
-        if hasattr(getattr(InstClass, method), 'pytestmark'):
-            Nargs =  len(getattr(InstClass, method).pytestmark)
-            names = [getattr(InstClass, method).pytestmark[j].name
-                     for j in range(0, Nargs)]
-            # Remove instruments imported from pysat
-            getattr(InstClass, method).pytestmark.clear()
-            # Add instruments from pysatModels
-            if InstClass == TestInstrumentsAll:
-                mark = pytest.mark.parametrize("name", instruments['names'])
-                getattr(InstClass, method).pytestmark.append(mark)
-            elif InstClass == TestInstrumentsDownload:
-                mark = pytest.mark.parametrize("inst", instruments['download'])
-                getattr(InstClass, method).pytestmark.append(mark)
-            elif InstClass == TestInstrumentsNoDownload:
-                mark = pytest.mark.parametrize("inst",
-                                               instruments['no_download'])
-                getattr(InstClass, method).pytestmark.append(mark)
+method_list = [func for func in dir(InstTestClass)
+               if callable(getattr(InstTestClass, func))]
+# Search tests for iteration via pytestmark, update instrument list
+for method in method_list:
+    if hasattr(getattr(InstTestClass, method), 'pytestmark'):
+        # Get list of names of pytestmarks
+        Nargs = len(getattr(InstTestClass, method).pytestmark)
+        names = [getattr(InstTestClass, method).pytestmark[j].name
+                 for j in range(0, Nargs)]
+        # Add instruments from your library
+        if 'all_inst' in names:
+            mark = pytest.mark.parametrize("name", instruments['names'])
+            getattr(InstTestClass, method).pytestmark.append(mark)
+        elif 'download' in names:
+            mark = pytest.mark.parametrize("inst", instruments['download'])
+            getattr(InstTestClass, method).pytestmark.append(mark)
+        elif 'no_download' in names:
+            mark = pytest.mark.parametrize("inst", instruments['no_download'])
+            getattr(InstTestClass, method).pytestmark.append(mark)
 
 
-class TestModels(TestInstrumentsAll):
-
-    __test__ = True
-
-    def setup(self):
-        """Runs before every method to create a clean testing setup."""
-        self.package = 'pysatModels.models'
-        pass
-
-    def teardown(self):
-        """Runs after every method to clean up previous testing."""
-        pass
-
-
-class TestModelsDownload(TestInstrumentsDownload):
-
-    __test__ = True
-
-    def setup(self):
-        """Runs before every method to create a clean testing setup."""
-        self.package = 'pysatModels.models'
-        pass
-
-    def teardown(self):
-        """Runs after every method to clean up previous testing."""
-        pass
-
-
-class TestModelsNoDownload(TestInstrumentsNoDownload):
-
-    __test__ = True
+class TestModels(InstTestClass):
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -33,8 +33,7 @@ class TestModels(InstTestClass):
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.package = 'pysatModels.models'
-        pass
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        pass
+        del self.package

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -2,8 +2,6 @@ import pytest
 
 import pysatModels
 
-import pysat.tests
-import pysat.tests.test_instruments
 from pysat.tests.test_instruments import generate_instrument_list
 from pysat.tests.test_instruments import TestInstrumentsAll
 from pysat.tests.test_instruments import TestInstrumentsDownload

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -1,0 +1,78 @@
+import pytest
+
+import pysatModels
+
+from pysat.tests.test_instruments import generate_instrument_list
+from pysat.tests.test_instruments import TestInstrumentsAll
+from pysat.tests.test_instruments import TestInstrumentsDownload
+from pysat.tests.test_instruments import TestInstrumentsNoDownload
+
+instruments = generate_instrument_list(pysatModels.models.__all__,
+                                       package='pysatModels.models')
+
+InstClasses = [TestInstrumentsAll, TestInstrumentsDownload,
+               TestInstrumentsNoDownload]
+
+for InstClass in InstClasses:
+    InstClass.__test__ = False
+    method_list = [func for func in dir(InstClass)
+                   if callable(getattr(InstClass, func))]
+    # Search tests for iteration via pytestmark, update instrument list
+    for method in method_list:
+        if hasattr(getattr(InstClass, method), 'pytestmark'):
+            Nargs =  len(getattr(InstClass, method).pytestmark)
+            names = [getattr(InstClass, method).pytestmark[j].name
+                     for j in range(0, Nargs)]
+            getattr(InstClass, method).pytestmark.clear()
+            if InstClass == TestInstrumentsAll:
+                mark = pytest.mark.parametrize("name", instruments['names'])
+                getattr(InstClass, method).pytestmark.append(mark)
+            elif InstClass == TestInstrumentsDownload:
+                mark = pytest.mark.parametrize("inst", instruments['download'])
+                getattr(InstClass, method).pytestmark.append(mark)
+            elif InstClass == TestInstrumentsNoDownload:
+                mark = pytest.mark.parametrize("inst",
+                                               instruments['no_download'])
+                getattr(InstClass, method).pytestmark.append(mark)
+
+
+class TestModels(TestInstrumentsAll):
+
+    __test__ = True
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.package = 'pysatModels.models'
+        pass
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        pass
+
+
+class TestModelsDownload(TestInstrumentsDownload):
+
+    __test__ = True
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.package = 'pysatModels.models'
+        pass
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        pass
+
+
+class TestModelsNoDownload(TestInstrumentsNoDownload):
+
+    __test__ = True
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.package = 'pysatModels.models'
+        pass
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        pass

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+markers =
+    all_inst: tests all instruments
+    download: tests for downloadable instruments
+    no_download: tests for instruments without download support
+    first: first tests to run
+    second: second tests to run

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-markers =
-    all_inst: tests all instruments
-    download: tests for downloadable instruments
-    no_download: tests for instruments without download support
-    first: first tests to run
-    second: second tests to run

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,10 @@
 [tool:pytest]
+markers =
+    all_inst: tests all instruments
+    download: tests for downloadable instruments
+    no_download: tests for instruments without download support
+    first: first tests to run
+    second: second tests to run
 flake8-ignore =
   *.py W503
   docs/conf.py ALL


### PR DESCRIPTION
# Description

Addresses #6 (partial)

- Tests the ucar_tiegcm object with the instrument test routines from pysat.  
- Updates properties of ucar_tiegcm to be consistent with pysat 3.0.0 changes

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

pytest -vs

**Test Configuration**:
* Mac OS X 10.15.6
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes

# Notes

- Tied to pysat/pysat#391 for now.  Will update to develop-3 once that is merged.
- In a general case, needs modifications for downloaded instruments.  Current code will clear `first` and `second` flags.  No downloaded models currently here.