### PR TITLE
readthedocs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,2 @@
-numpy
 numpydoc
 m2r
-pysat

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
-numpydoc
 m2r
+numpy
+numpydoc
+PyForecastTools
+pysat

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@
 # Full license can be found in License.md and AUTHORS.md
 # -----------------------------------------------------------------------------
 
-import os
 import codecs
+import os
 from setuptools import setup, find_packages
 
 
@@ -16,13 +16,11 @@ version_filename = os.path.join('pysatModels', 'version.txt')
 with codecs.open(os.path.join(here, version_filename)) as version_file:
     version = version_file.read().strip()
 
-# change setup.py for readthedocs - commented for now
-# on_rtd = os.environ.get('READTHEDOCS') == 'True'
+# Define requirements
 install_requires = ['pysat', 'scipy', 'pandas', 'xarray', 'numpy',
                     'PyForecastTools']
 
 # Run setup
-
 setup(name='pysatModels',
       version=version,
       url='github.com/pysat/pysatModels',
@@ -31,20 +29,16 @@ setup(name='pysatModels',
       description='Model-data comparisons for the pysat ecosystem',
       long_description=long_description,
       packages=find_packages(),
-      classifiers=[
-          "Development Status :: 4 - Beta",
-          "Topic :: Scientific/Engineering :: Physics",
-          "Intended Audience :: Science/Research",
-          "License :: BSD",
-          "Natural Language :: English",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Programming Language :: Python :: 3.8",
-          "Operating System :: MacOS :: MacOS X",
-      ],
+      classifiers=["Development Status :: 4 - Beta",
+                   "Topic :: Scientific/Engineering :: Physics",
+                   "Intended Audience :: Science/Research",
+                   "License :: BSD",
+                   "Natural Language :: English",
+                   "Programming Language :: Python :: 3.5",
+                   "Programming Language :: Python :: 3.6",
+                   "Programming Language :: Python :: 3.7",
+                   "Programming Language :: Python :: 3.8",
+                   "Operating System :: MacOS :: MacOS X",],
       include_package_data=True,
       zip_safe=False,
-      install_requires=install_requires,
-      )
+      install_requires=install_requires,)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ with codecs.open(os.path.join(here, version_filename)) as version_file:
 
 # change setup.py for readthedocs - commented for now
 # on_rtd = os.environ.get('READTHEDOCS') == 'True'
-install_requires = ['pysat', 'scipy', 'pandas', 'xarray', 'numpy']
+install_requires = ['pysat', 'scipy', 'pandas', 'xarray', 'numpy',
+                    'PyForecastTools']
 
 # Run setup
 


### PR DESCRIPTION
Fixes bug in documentation where docstrings were not showing up on readthedocs.  Partially addresses #35.

Also fixes `setup.py`, adding PyForecastTools as a requirement and making some style fixes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested by running the branch on readthedocs.

**Test Configuration**:
* Operating system: readthedocs
* Version number: 3.7.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
