### PR TITLE
STY/BUG: pysat 3.0 style conventions, logger DeprecationWarning

### DIFF
--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -25,6 +25,7 @@ Loads into xarray format.
 from __future__ import print_function
 from __future__ import absolute_import
 
+import datetime as dt
 import warnings
 
 import xarray as xr
@@ -47,7 +48,7 @@ sat_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported!
 # format is outer dictionary has sat_id as the key
 # each sat_id has a dictionary of test dates keyed by tag string
-test_dates = {'': {'': pysat.datetime(2019, 1, 1)}}
+test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 
 # specify using xarray (not using pandas)
 pandas_format = False

--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -800,7 +800,7 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
                     if str(verr).find("requested xi is out of bounds") > 0:
                         # This is acceptable, pad the interpolated data with
                         # NaN
-                        ps_mod.logger.warn(
+                        ps_mod.logger.warning(
                             "{:} for {:s} data at {:}".format(verr, mdat, xi))
                         yi = [np.nan]
                     else:


### PR DESCRIPTION
# Description

Pysat 3.0.0 will no longer carry around datetime, DataFrame, and Series objects.  Libraries should import these directly from datetime and pandas.  This had been removed in pysat/pysat#369, but needs to be fixed in the dependent libraries before it can be merged there.  Pre-emptively fixing bugs before they propagate down.  These objects have been found via global search.

Also updates `logger.warn` to `logger.warning` in response to a DeprecationWarning.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally with the `pandas_update` branch of pysat and pytest.

**Test Configuration**:
* Mac OS X 10.15.4
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
