### PR TITLE
TST: update use of test_instrument_class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout develop-3
+  - git checkout remove_madrigal
   - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   - cd ../pysatModels

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Create conda test environment
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 nose pytest-cov pytest-ordering coveralls future
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 nose pytest-cov pytest-ordering future
   - conda activate test-environment
   # check for custom version of numpy
   - if [ -z ${NUMPY_VER} ]; then
@@ -42,6 +42,8 @@ install:
   - pip install pysatCDF >/dev/null
   # Install packages not on conda
   - pip install pytest-flake8
+  # conda using old coveralls (1.5.2) which is not working on Travis CI
+  - pip install coveralls
   # Prepare pysat install from git
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout remove_madrigal
+  - git checkout develop-3
   - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   # install pysatModels

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -4,8 +4,7 @@ import pysatModels
 from pysat.tests.instrument_test_class import generate_instrument_list
 from pysat.tests.instrument_test_class import InstTestClass
 
-instruments = generate_instrument_list(pysatModels.models.__all__,
-                                       package='pysatModels.models')
+instruments = generate_instrument_list(package=pysatModels.models)
 
 method_list = [func for func in dir(InstTestClass)
                if callable(getattr(InstTestClass, func))]
@@ -32,7 +31,7 @@ class TestModels(InstTestClass):
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
-        self.package = 'pysatModels.models'
+        self.package = pysatModels.models
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""


### PR DESCRIPTION
# Description

Changes to the pysat test_instrument_class are implemented in pysat/pysat#420 for improved interface with instrument libraries that have downloadable instruments.  This updates the syntax here to match the new routines.

Temporarily using the `remove_madrigal` pysat branch while in draft form.  Will update once pysat develop-3 is updated.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally via pytest with the remove_madrigal branch of pysat.

**Test Configuration**:
* Mac OS X 10.15.4
* python 3.7.3
* pytest 5.4.1

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
