### PR TITLE
Unit tests for extract routine `extract_modelled_observations`

### DIFF
--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -137,7 +137,7 @@ class TestUtilsExtractModObs:
         for label in self.input_kwargs['sel_name']:
             if label not in self.input_args[3]:
                 # Test each of the extracted model data columns
-                tcol =  "{:s}_{:s}".format(self.model_label, label)
+                tcol = "{:s}_{:s}".format(self.model_label, label)
                 assert tcol in self.out
                 assert tcol in self.inst.data.columns
                 assert (self.inst.data[self.input_args[2][0]].shape
@@ -162,7 +162,6 @@ class TestUtilsExtractModObs:
             self.out = self.log_capture.getvalue()
             assert self.out.find('model data already interpolated') >= 0
 
-
         assert str(err.value.args[0]).find(
             'instrument object already contains all model data') >= 0
 
@@ -184,7 +183,7 @@ class TestUtilsExtractModObs:
         for label in all_sel:
             if label not in self.input_args[3]:
                 # Test each of the extracted model data columns
-                tcol =  "{:s}_{:s}".format(self.model_label, label)
+                tcol = "{:s}_{:s}".format(self.model_label, label)
                 assert tcol in self.inst.data.columns
                 assert (self.inst.data[self.input_args[2][0]].shape
                         == self.inst.data[tcol].shape)

--- a/pysatModels/tests/test_utils_match.py
+++ b/pysatModels/tests/test_utils_match.py
@@ -92,7 +92,8 @@ class TestUtilsMatchLoadModelXarray:
         """ Test return value of None with empty instrument load
         """
         self.model_inst = pysat.Instrument(**self.model_kwargs)
-        self.ftime = self.model_inst.files.files.index[0] - dt.timedelta(days=1)
+        self.ftime = self.model_inst.files.files.index[0] - dt.timedelta(
+            days=1)
         self.xout = match.load_model_xarray(self.ftime, self.model_inst)
 
         assert self.xout is None
@@ -161,7 +162,7 @@ class TestUtilsMatchCollectInstModPairs:
             assert lout.find('unable to load model data at') >= 0
         else:
             self.required_kwargs['model_load_kwargs'] = {}
-            with pytest.raises(TypeError, match=mout) as terr:
+            with pytest.raises(TypeError, match=mout):
                 match.collect_inst_model_pairs(*self.input_args,
                                                **self.required_kwargs)
 
@@ -183,7 +184,7 @@ class TestUtilsMatchCollectInstModPairs:
         """
         del self.required_kwargs[del_key]
 
-        with pytest.raises(ValueError, match=err_msg) as verr:
+        with pytest.raises(ValueError, match=err_msg):
             match.collect_inst_model_pairs(*self.input_args,
                                            **self.required_kwargs)
 
@@ -197,7 +198,7 @@ class TestUtilsMatchCollectInstModPairs:
         """
         self.required_kwargs[cng_key] = bad_val
 
-        with pytest.raises(ValueError, match=err_msg) as verr:
+        with pytest.raises(ValueError, match=err_msg):
             match.collect_inst_model_pairs(*self.input_args,
                                            **self.required_kwargs)
 
@@ -226,12 +227,13 @@ class TestUtilsMatchCollectInstModPairs:
         assert isinstance(self.out.data, xr.Dataset)
         assert self.ref_col in [kk for kk in self.out.data.data_vars.keys()]
         assert len(self.out.data.data_vars[self.ref_col]) == num
-        assert np.all(np.isfinite(self.out.data.data_vars[self.ref_col].values))
+        assert np.all(np.isfinite(
+            self.out.data.data_vars[self.ref_col].values))
 
     @pytest.mark.parametrize("lin,lout,test_out",
-                             [([-179.0,179.0], [-180.0,180.0], 3),
-                              ([0.5,359.0], [0.0,360.0], 3),
-                              ([-1.0,210.0], None,
+                             [([-179.0, 179.0], [-180.0, 180.0], 3),
+                              ([0.5, 359.0], [0.0, 360.0], 3),
+                              ([-1.0, 210.0], None,
                                'unexpected longitude range')])
     def test_lon_output(self, lin, lout, test_out):
         """ Test the match handling with different longitude range input
@@ -248,7 +250,7 @@ class TestUtilsMatchCollectInstModPairs:
                     mdata.coords['longitude'] = np.linspace(
                         *lin, mdata.dims['longitude'])
             return mdata
-        
+
         self.required_kwargs['model_load_rout'] = lon_model_load
         self.required_kwargs['model_label'] = 'tmodel'
         self.required_kwargs['sel_name'] = [self.ref_col]
@@ -260,7 +262,7 @@ class TestUtilsMatchCollectInstModPairs:
             self.required_kwargs['mod_lon_name'] = 'glon'
             self.required_kwargs['mod_name'][0] = 'glon'
 
-            with pytest.raises(ValueError, match=test_out) as verr:
+            with pytest.raises(ValueError, match=test_out):
                 match.collect_inst_model_pairs(*self.input_args,
                                                **self.required_kwargs)
 
@@ -271,7 +273,8 @@ class TestUtilsMatchCollectInstModPairs:
                                                       **self.required_kwargs)
 
             assert isinstance(self.out.data, xr.Dataset)
-            assert self.ref_col in [kk for kk in self.out.data.data_vars.keys()]
+            assert self.ref_col in [kk for kk
+                                    in self.out.data.data_vars.keys()]
             assert len(self.out.data.data_vars[self.ref_col]) == test_out
             assert np.all(np.isfinite(
                 self.out.data.data_vars[self.ref_col].values))
@@ -297,7 +300,8 @@ class TestUtilsMatchCollectInstModPairs:
     def test__inst_download_missing(self):
         """ Test the download data loop, which will fail to download anything
         """
-        self.input_args[0] = self.inst.files.files.index[0]-dt.timedelta(days=1)
+        self.input_args[0] = self.inst.files.files.index[0] - dt.timedelta(
+            days=1)
         self.input_args[1] = self.inst.files.files.index[0]
 
         self.out = match.collect_inst_model_pairs(*self.input_args,

--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -818,9 +818,9 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
                 try:
                     interp_data[attr_name][xout] = yi[0]
                 except TypeError as terr:
-                    ps_mod.logger.error(''.join(['check mod_name input against',
-                                                 ' dimensions for ', mdat,
-                                                 ' in model data']))
+                    ps_mod.logger.error(''.join(['check mod_name input ',
+                                                 'against dimensions for ',
+                                                 mdat, ' in model data']))
                     raise TypeError(terr)
 
     # Update the instrument object and attach units to the metadata

--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -691,14 +691,18 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
                    np.full(shape=interp_shape, fill_value=np.nan)
                    for mdat in sel_name}
 
+    del_list = list()
     for mdat in interp_data.keys():
         if mdat in inst.data.keys():
             ps_mod.logger.warning("".join(["model data already interpolated:",
                                            " {:}".format(mdat)]))
-            del interp_data[mdat]
+            del_list.append(mdat)
 
-    if len(interp_data.keys()) == 0:
+    if len(interp_data.keys()) == len(del_list):
         raise ValueError("instrument object already contains all model data")
+    elif len(del_list) > 0:
+        for mdat in del_list:
+            del interp_data[mdat]
 
     for i, ii in enumerate(iind):
         # Cycle through each model data type, since it may not depend on
@@ -707,8 +711,12 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
             # Define the output key
             attr_name = "{:s}_{:s}".format(model_label, mdat)
 
+            # Skip if this is already included in the output instrument
+            if attr_name not in interp_data.keys():
+                break
+
             # Determine the dimension values
-            dims = list(model.data_vars[mdat].dims)
+            dims = [kk for kk in model.data_vars[mdat].dims]
             indices = {mod_time_name: mind[i]}
 
             # Construct the data needed for interpolation, ensuring that

--- a/pysatModels/utils/match.py
+++ b/pysatModels/utils/match.py
@@ -200,7 +200,7 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs={},
                                                      closed='left')
                          if tt not in inst.files[start:stop].index]
         for tt in missing_times:
-            inst.download(start=tt, stop=tt+pds.DateOffset(days=1),
+            inst.download(start=tt, stop=tt + pds.DateOffset(days=1),
                           **inst_download_kwargs)
 
     # Cycle through the times, loading the model and instrument data as needed
@@ -288,8 +288,8 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs={},
                         matched_inst.data = inst[im]
                     else:
                         idata = inst[im]
-                        matched_inst.data = inst.concat_data([matched_inst.data,
-                                                              idata])
+                        matched_inst.data = inst.concat_data(
+                            [matched_inst.data, idata])
 
                     # Reset the clean flag
                     inst.clean_level = 'none'


### PR DESCRIPTION
# Description

Fixed and added more unit tests for the `extract_modelled_observations` routine in `utils.extract`.

Partially addresses #6 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests run locally `python3 -m pytest test_utils_extract.py::TestUtilsExtractModObs` from the test directory. 

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
