### PR TITLE
TST: use conda to manage travis env & NEP29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 dist: xenial
 jobs:
   include:
+    - name: Minimum NEP 029 versions
+      python: 3.6
+      env: NUMPY_VER=1.15
+    # Versions with latest numpy
     - python: 3.6
     - python: 3.7
 
@@ -12,21 +16,31 @@ addons:
     packages:
     - gfortran
 
-before_install:
-  - pip install pytest-cov
-  - pip install pytest-flake8
-  - pip install coveralls
-  - pip install future
-  - pip install numpy
-  - pip install scipy
-  - pip install pandas
-  - pip install xarray
-  - pip install matplotlib
-# Travis CI currently not working with netCDF4 1.5.3
-  - pip install 'cftime==1.1.1'
-  - pip install 'netCDF4<1.5.3'
-# Install pysatCDF and dump output
+install:
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - hash -r
+  - conda config --set always_yes True --set changeps1 False
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  # Create conda test environment
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 nose pytest-cov pytest-ordering coveralls future
+  - conda activate test-environment
+  # check for custom version of numpy
+  - if [ -z ${NUMPY_VER} ]; then
+      echo 'Using latest numpy';
+    else
+      conda install numpy==$NUMPY_VER;
+    fi
+  # Install pysatCDF and dump output
   - pip install pysatCDF >/dev/null
+  # Install packages not on conda
+  - pip install pytest-flake8
   # Prepare pysat install from git
   - cd ..
   - git clone https://github.com/pysat/pysat.git >/dev/null
@@ -37,9 +51,8 @@ before_install:
   - git checkout develop-3
   - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
+  # install pysatModels
   - cd ../pysatModels
-
-install:
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - gfortran
 
 install:
+  # Use the conda management under the install script, as separate scripts will revert to pip
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.


### PR DESCRIPTION
# Description

Following on from pysat/pysat#409, uses conda to manage the test env in Travis CI.  This allows the artificial caps on netCDF4 and other packages to be removed.

Also includes a round of testing for numpy 1.15 with python 3.6, which are the minimum required versions for NEP 29 compliance.

https://numpy.org/neps/nep-0029-deprecation_policy.html

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Changes to Travis env, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
