### PR TITLE
BUG: custom input changed

### DIFF
--- a/pysatModels/utils/match.py
+++ b/pysatModels/utils/match.py
@@ -239,8 +239,9 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs={},
 
                 # Set the range of the instrument longitude
                 inst.custom.attach(pysat.utils.coords.update_longitude,
-                                   'modify', low=lon_low,
-                                   lon_name=inst_lon_name, high=lon_high)
+                                   'modify', kwargs={'low': lon_low,
+                                                     'lon_name': inst_lon_name,
+                                                     'high': lon_high})
                 inst.load(date=istart)
 
                 # Set flag to false now that the range has been set


### PR DESCRIPTION
The way custom function input is specified changed to use `args` and `kwargs` in `pysat` PR 433: https://github.com/pysat/pysat/pull/433

This PR looked for all implementations of `custom` and updated them.  Addresses issue #45.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was found/tested by running `match.collect_inst_model_pairs` with longitude updating.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7.7
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
