### PR TITLE
TST: use numpy 1.16 as the minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   include:
     - name: Minimum NEP 029 versions
       python: 3.6
-      env: NUMPY_VER=1.15
+      env: NUMPY_VER=1.16
     # Versions with latest numpy
     - python: 3.6
     - python: 3.7


### PR DESCRIPTION
# Description

The latest matplotlib (3.3.0rc1) requires numpy 1.16.  Since NEP 29 drops 1.15 support on July 23 and no release is planned before then, dropping this now to keep travis tests running smoothly .

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Change to Travis CI configuration, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
