### PR TITLE
ENH: add sami2py model object

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-
-[report]

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,4 +62,4 @@ script:
   - pytest -vs --cov=pysatModels/  --flake8
 
 after_success:
-  - coveralls
+  - coveralls --rcfile=setup.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout icon_updates
+  - git checkout develop-3
   - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   # install pysatModels

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - git checkout develop-3
+  - git checkout icon_updates
   - python setup.py install >/dev/null
   - export PYTHONPATH=$PYTHONPATH:$(pwd)
   # install pysatModels

--- a/docs/supported_models.rst
+++ b/docs/supported_models.rst
@@ -1,6 +1,22 @@
 Supported Models
 ================
 
+SAMI2
+-----
+
+Supports the SAMI2 (Sami2 is Another Model of the Ionosphere) model through the
+sami2py interface. Sami2py is a python module that runs the SAMI2 model, as well
+as archives, loads and plots the resulting modeled values. SAMI2 is a model
+developed by the Naval Research Laboratory to simulate the motions of plasma
+in a 2D ionospheric environment along a dipole magnetic field [Huba et al, 2000].
+Information about this model can be found at the
+`sami2py github page <https://github.com/sami2py/sami2py>`_,
+along with a list of the
+`principle papers <https://sami2py.readthedocs.io/en/latest/introduction.html#references>`_.
+
+.. automodule:: pysatModels.models.sami2py_sami2
+   :members:
+
 TIE-GCM
 -------
 

--- a/pysatModels/models/__init__.py
+++ b/pysatModels/models/__init__.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # Import key modules and skip F401 testing in flake8
+from pysatModels.models import sami2py_sami2  # noqa: F401
 from pysatModels.models import ucar_tiegcm  # noqa: F401
 
-__all__ = ['ucar_tiegcm']
+__all__ = ['sami2py_sami2', 'ucar_tiegcm']

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+"""
+Supports loading data from files generated using TIEGCM
+(Thermosphere Ionosphere Electrodynamics General Circulation Model) model.
+TIEGCM file is a netCDF file with multiple dimensions for some variables.
+
+Parameters
+----------
+platform : string
+    'sami2py'
+name : string
+    'sami2'
+tag : string
+    None supported
+sat_id : string
+    None supported
+
+Notes
+-----
+Loads into xarray format.
+
+"""
+
+# python 2/3 comptability
+from __future__ import print_function
+from __future__ import absolute_import
+
+import datetime as dt
+import os
+import requests
+import warnings
+
+import xarray as xr
+import pysat
+
+platform = 'sami2py'
+name = 'sami2'
+
+# dictionary of data 'tags' and corresponding description
+tags = {'': 'sami2py output file',
+        'test': 'Standard output of sami2py for benchmarking'}
+sat_ids = {'': ['']}
+# good day to download test data for. Downloads aren't currently supported!
+# format is outer dictionary has sat_id as the key
+# each sat_id has a dictionary of test dates keyed by tag string
+_test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
+_test_download = {'': {'': False, 'test': True}}
+
+# specify using xarray (not using pandas)
+pandas_format = False
+
+
+def init(self):
+    """Initializes the Instrument object with instrument specific values.
+
+    Runs once upon instantiation.
+
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+
+    """
+
+    print(" ".join(["References and information about TIEGCM are available at",
+                    "https://www.hao.ucar.edu/modeling/tgcm/index.php"]))
+    return
+
+
+def load(fnames, tag=None, sat_id=None, **kwargs):
+    """Loads TIEGCM data using xarray.
+
+    This routine is called as needed by pysat. It is not intended
+    for direct user interaction.
+
+    Parameters
+    ----------
+    fnames : array-like
+        iterable of filename strings, full path, to data files to be loaded.
+        This input is nominally provided by pysat itself.
+    tag : string ('')
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    sat_id : string ('')
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    **kwargs : extra keywords
+        Passthrough for additional keyword arguments specified when
+        instantiating an Instrument object. These additional keywords
+        are passed through to this routine by pysat.
+
+    Returns
+    -------
+    data : xarray.Dataset
+        pysat formatted xarray Dataset
+    metadata : pysat.Metadata
+        Model run meta data
+
+    Notes
+    -----
+    Any additional keyword arguments passed to pysat.Instrument
+    upon instantiation are passed along to this routine.
+
+    Examples
+    --------
+    ::
+
+
+        inst = pysat.Instrument('ucar', 'tiegcm')
+        inst.load(2019,1)
+
+    """
+
+    # load data
+    data = xr.open_dataset(fnames[0])
+    # move attributes to the Meta object
+    # these attributes will be trasnferred to the Instrument object
+    # automatically by pysat
+    meta = pysat.Meta()
+    for attr in data.attrs:
+        setattr(meta, attr[0], attr[1])
+    data.attrs = []
+
+    # fill Meta object with variable information
+    for key in data.variables.keys():
+        attrs = data.variables[key].attrs
+        meta[key] = attrs
+
+    return data, meta
+
+
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
+    """Produce a list of files corresponding to UCAR TIEGCM.
+
+    Parameters
+    ----------
+    tag : string ('')
+        tag name used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    sat_id : string ('')
+        Satellite ID used to identify particular data set to be loaded.
+        This input is nominally provided by pysat itself.
+    data_path : string (None)
+        Full path to directory containing files to be loaded. This
+        is provided by pysat. The user may specify their own data path
+        at Instrument instantiation and it will appear here.
+    format_str : string (None)
+        String template used to parse the datasets filenames. If a user
+        supplies a template string at Instrument instantiation
+        then it will appear here, otherwise defaults to None.
+
+    Returns
+    -------
+    pandas.Series
+        Series of filename strings, including the path, indexed by datetime.
+
+    Notes
+    -----
+    This routine is invoked by pysat and is not intended for direct
+    use by the end user. Arguments are provided by pysat.
+
+    Multiple data levels may be supported via the 'tag' input string.
+
+    The returned Series should not have any duplicate datetimes. If there are
+    multiple versions of a file the most recent version should be kept and the
+    rest discarded. This routine uses the pysat.Files.from_os constructor, thus
+    the returned files are up to pysat specifications.
+
+    Examples
+    --------
+    ::
+
+
+        If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
+        is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
+        'v{version:02d}r{revision:04d}.NC'
+
+    """
+
+    if format_str is None:
+        # default file naming
+        format_str = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
+
+    return pysat.Files.from_os(data_path=data_path, format_str=format_str)
+
+
+def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
+             password=None, **kwargs):
+    """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
+
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need not
+        be contiguous.
+    tag : string ('')
+        Tag identifier used for particular dataset. This input is provided by
+        pysat.
+    sat_id : string  ('')
+        Satellite ID string identifier used for particular dataset. This input
+        is provided by pysat.
+    data_path : string (None)
+        Path to directory to download data to.
+    user : string (None)
+        User string input used for download. Provided by user and passed via
+        pysat. If an account
+        is required for dowloads this routine here must error if user not
+        supplied.
+    password : string (None)
+        Password for data download.
+    **kwargs : dict
+        Additional keywords supplied by user when invoking the download
+        routine attached to a pysat.Instrument object are passed to this
+        routine via kwargs.
+
+    Notes
+    -----
+    This routine is invoked by pysat and is not intended for direct use by
+    the end user.
+
+    """
+
+    if tag == 'test':
+        remote_url = 'https://github.com/sami2py/sami2py/'
+        remote_path = 'blob/main/sami2py/tests/test_data/'
+        # Need to tell github to show the raw data, not the webpage version
+        fname = 'sami2py_output.nc?raw=true'
+        # Create pysat-compatible name
+        format_str = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
+        saved_local_fname = os.path.join(data_path,
+                                         format_str.format(year=2019,
+                                                           month=1, day=1))
+        remote_path = '/'.join((remote_url.strip('/'), remote_path.strip('/'),
+                                fname))
+        req = requests.get(remote_path)
+        if req.status_code != 404:
+            open(saved_local_fname, 'wb').write(req.content)
+
+    else:
+        warnings.warn('Not implemented in this version.')
+    return

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -71,9 +71,22 @@ def init(self):
 
     """
 
-    logger.info("".join(["References and information about samip2y are ",
-                         "available at https://sami2py.readthedocs.io/en/",
-                         "latest/introduction.html#references"]))
+    self.meta.acknowledgments = " ".join(("This work uses the SAMI2 ionosphere",
+                                          "model written and developed by the",
+                                          "Naval Research Laboratory."))
+    self.meta.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
+                                     "Sami2 is Another Model of the Ionosphere",
+                                     "(SAMI2): A new low‐latitude ionosphere",
+                                     "model, J. Geophys. Res., 105, Pages",
+                                     "23035-23053,",
+                                     "https://doi.org/10.1029/2000JA000035,",
+                                     "2000.\n",
+                                     "Klenzing, J., Jonathon Smith, Michael",
+                                     "Hirsch, & Angeline G. Burrell. (2020,",
+                                     "July 17). sami2py/sami2py: Version 0.2.2",
+                                     "(Version v0.2.2). Zenodo.",
+                                     "http://doi.org/10.5281/zenodo.3950564"))
+    logger.info(self.meta.acknowledgments)
 
 
 def load(fnames, tag=None, sat_id=None, **kwargs):

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -216,9 +216,13 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
     This routine is invoked by pysat and is not intended for direct use by
     the end user.
 
+    The test object generates the datetime requested by thte user, which may not
+    match the date of the model run.
+
     """
 
     if tag == 'test':
+        date = date_array[0]
         remote_url = 'https://github.com/sami2py/sami2py/'
         remote_path = 'blob/main/sami2py/tests/test_data/'
         # Need to tell github to show the raw data, not the webpage version
@@ -226,8 +230,9 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
         # Create pysat-compatible name
         format_str = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
         saved_local_fname = os.path.join(data_path,
-                                         format_str.format(year=2019,
-                                                           month=1, day=1))
+                                         format_str.format(year=date.year,
+                                                           month=date.month,
+                                                           day=date.day))
         remote_path = '/'.join((remote_url.strip('/'), remote_path.strip('/'),
                                 fname))
         req = requests.get(remote_path)

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -44,7 +44,7 @@ tags = {'': 'sami2py output file',
 sat_ids = {'': ['']}
 _test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
 _test_download = {'': {'': False,
-                       'test': True}}
+                       'test': False}}
 
 # specify using xarray (not using pandas)
 pandas_format = False

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 
 import datetime as dt
 import functools
+import logging
 import os
 import requests
 import warnings
@@ -33,6 +34,9 @@ import warnings
 import xarray as xr
 import pysat
 from pysat.instruments.methods import general as mm_gen
+
+
+logger = logging.getLogger(__name__)
 
 platform = 'sami2py'
 name = 'sami2'
@@ -67,9 +71,9 @@ def init(self):
 
     """
 
-    print("".join(["References and information about samip2y are available at ",
-                   "https://sami2py.readthedocs.io/en/latest/introduction.html",
-                   "#references"]))
+    logger.info("".join(["References and information about samip2y are ",
+                         "available at https://sami2py.readthedocs.io/en/",
+                         "latest/introduction.html#references"]))
 
 
 def load(fnames, tag=None, sat_id=None, **kwargs):
@@ -194,5 +198,5 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
             open(saved_local_fname, 'wb').write(req.content)
 
     else:
-        warnings.warn('Not implemented in this version.')
+        warnings.warn('Downloads currently only supported for test files.')
     return

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -40,11 +40,9 @@ name = 'sami2'
 tags = {'': 'sami2py output file',
         'test': 'Standard output of sami2py for benchmarking'}
 sat_ids = {'': ['']}
-# good day to download test data for. Downloads aren't currently supported!
-# format is outer dictionary has sat_id as the key
-# each sat_id has a dictionary of test dates keyed by tag string
 _test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
-_test_download = {'': {'': False, 'test': True}}
+_test_download = {'': {'': False,
+                       'test': True}}
 
 # specify using xarray (not using pandas)
 pandas_format = False
@@ -62,13 +60,13 @@ def init(self):
 
     """
 
-    print(" ".join(["References and information about TIEGCM are available at",
-                    "https://www.hao.ucar.edu/modeling/tgcm/index.php"]))
-    return
+    print("".join(["References and information about samip2y are available at ",
+                   "https://sami2py.readthedocs.io/en/latest/introduction.html",
+                   "#references"]))
 
 
 def load(fnames, tag=None, sat_id=None, **kwargs):
-    """Loads TIEGCM data using xarray.
+    """Loads sami2py data using xarray.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.
@@ -106,8 +104,8 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     ::
 
 
-        inst = pysat.Instrument('ucar', 'tiegcm')
-        inst.load(2019,1)
+        inst = pysat.Instrument('sami2py', 'sami2')
+        inst.load(2019, 1)
 
     """
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Supports loading data from files generated using TIEGCM
-(Thermosphere Ionosphere Electrodynamics General Circulation Model) model.
-TIEGCM file is a netCDF file with multiple dimensions for some variables.
+Supports loading data from files generated using the sami2py model.
+sami2py file is a netCDF file with multiple dimensions for some variables.
 
 Parameters
 ----------
@@ -139,7 +138,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
 
 def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
              password=None, **kwargs):
-    """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
+    """Downloads sami2py data.  Currently only retrieves test data from github
 
     Parameters
     ----------
@@ -171,7 +170,7 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
     This routine is invoked by pysat and is not intended for direct use by
     the end user.
 
-    The test object generates the datetime requested by thte user, which may not
+    The test object generates the datetime requested by the user, which may not
     match the date of the model run.
 
     """

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -44,7 +44,7 @@ tags = {'': 'sami2py output file',
 sat_ids = {'': ['']}
 _test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
 _test_download = {'': {'': False,
-                       'test': False}}
+                       'test': True}}
 
 # specify using xarray (not using pandas)
 pandas_format = False
@@ -119,6 +119,8 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
 
     # load data
     data = xr.open_dataset(fnames[0])
+    # rename time variable to be pysat compatible
+    data = data.rename({'ut': 'time'})
     # move attributes to the Meta object
     # these attributes will be trasnferred to the Instrument object
     # automatically by pysat

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -49,7 +49,7 @@ _test_download = {'': {'': False,
 # specify using xarray (not using pandas)
 pandas_format = False
 
-fname = 'sami2py_output_{year:04d}{month:02d}{day:02d}.nc'
+fname = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
 supported_tags = {'': {'': fname,
                        'test': fname}}
 list_files = functools.partial(mm_gen.list_files,

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -26,12 +26,14 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import datetime as dt
+import functools
 import os
 import requests
 import warnings
 
 import xarray as xr
 import pysat
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'sami2py'
 name = 'sami2'
@@ -46,6 +48,12 @@ _test_download = {'': {'': False,
 
 # specify using xarray (not using pandas)
 pandas_format = False
+
+fname = 'sami2py_output_{year:04d}{month:02d}{day:02d}.nc'
+supported_tags = {'': {'': fname,
+                       'test': fname}}
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags)
 
 
 def init(self):
@@ -127,61 +135,6 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return data, meta
 
 
-def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
-    """Produce a list of files corresponding to UCAR TIEGCM.
-
-    Parameters
-    ----------
-    tag : string ('')
-        tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
-        Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    data_path : string (None)
-        Full path to directory containing files to be loaded. This
-        is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
-        String template used to parse the datasets filenames. If a user
-        supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
-
-    Returns
-    -------
-    pandas.Series
-        Series of filename strings, including the path, indexed by datetime.
-
-    Notes
-    -----
-    This routine is invoked by pysat and is not intended for direct
-    use by the end user. Arguments are provided by pysat.
-
-    Multiple data levels may be supported via the 'tag' input string.
-
-    The returned Series should not have any duplicate datetimes. If there are
-    multiple versions of a file the most recent version should be kept and the
-    rest discarded. This routine uses the pysat.Files.from_os constructor, thus
-    the returned files are up to pysat specifications.
-
-    Examples
-    --------
-    ::
-
-
-        If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
-        is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
-        'v{version:02d}r{revision:04d}.NC'
-
-    """
-
-    if format_str is None:
-        # default file naming
-        format_str = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
-
-    return pysat.Files.from_os(data_path=data_path, format_str=format_str)
-
-
 def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
              password=None, **kwargs):
     """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
@@ -227,8 +180,8 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
         remote_path = 'blob/main/sami2py/tests/test_data/'
         # Need to tell github to show the raw data, not the webpage version
         fname = 'sami2py_output.nc?raw=true'
-        # Create pysat-compatible name
-        format_str = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
+        # Use pysat-compatible name
+        format_str = supported_tags[sat_id][tag]
         saved_local_fname = os.path.join(data_path,
                                          format_str.format(year=date.year,
                                                            month=date.month,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[coverage:run]
+
+[coverage:report]
+
 [flake8]
 max-line-length = 80
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 80
+
 [tool:pytest]
 markers =
     all_inst: tests all instruments


### PR DESCRIPTION
# Description

Addresses #44 

Adds an instrument object for sami2py, including download support for the test data file hosted at the sami2py github page. 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import datetime as dt
import pysat
from pysatModels.models import sami2py_sami2
sami2 = pysat.Instrument(inst_module=sami2py_sami2, tag='test')
sami2.download(dt.datetime(2019, 1, 1), dt.datetime(2019, 1, 1))
sami2.load(2019, 1)
```

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
