### PR TITLE
DOC: rename default as main in docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@ your test configuration
 
 # Checklist:
 
-- [ ] Make sure you are merging into the ``develop`` (not ``master``) branch
+- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 </div>
 
 # pysatModels
-[![Build Status](https://travis-ci.org/pysat/pysatModels.svg?branch=master)](https://travis-ci.org/pysat/pysatModels)
-[![Coverage Status](https://coveralls.io/repos/github/pysat/pysatModels/badge.svg?branch=master)](https://coveralls.io/github/pysat/pysatModels?branch=master)
+[![Build Status](https://travis-ci.org/pysat/pysatModels.svg?branch=main)](https://travis-ci.org/pysat/pysatModels)
+[![Coverage Status](https://coveralls.io/repos/github/pysat/pysatModels/badge.svg?branch=main)](https://coveralls.io/github/pysat/pysatModels?branch=master)
 
 This module handles model centric data loading through pysat and contains a
-variety of tools to perform model-data analysis, including model validation. 
+variety of tools to perform model-data analysis, including model validation.
 
 ## Getting started
 
@@ -45,4 +45,3 @@ the Space Physics community.  This module officially supports Python 3.6+.
 ## Examples
 
 Coming soon
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # pysatModels
 [![Build Status](https://travis-ci.org/pysat/pysatModels.svg?branch=main)](https://travis-ci.org/pysat/pysatModels)
-[![Coverage Status](https://coveralls.io/repos/github/pysat/pysatModels/badge.svg?branch=main)](https://coveralls.io/github/pysat/pysatModels?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/pysat/pysatModels/badge.svg?branch=main)](https://coveralls.io/github/pysat/pysatModels?branch=main)
 
 This module handles model centric data loading through pysat and contains a
 variety of tools to perform model-data analysis, including model validation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ templates_path = ['.templates']
 # source_suffix = ['.rst', '.md']
 source_suffix = '.rst'
 
-# The master toctree document.
+# The main toctree document (using required variable name).
 master_doc = 'index'
 
 # General information about the project.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. pysatModels documentation master file.  Rembemer that it should at least
+.. pysatModels documentation main file.  Remember that it should at least
    contain the root `toctree` directive.
 
 Welcome to the pysatModels documentation


### PR DESCRIPTION
# Description

Following the style set up in other pulls.  Renaming default branch as `main`.  NOTE: updated the front page and template info with the creation of main, since we are still not to a release point here.  Tests on `main` failing because of changes instituted when the package changed name.

## Type of change

- This change is a documentation update

# How Has This Been Tested?

verifying the badges are working correctly

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
