### PR TITLE
Inst test update

### DIFF
--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -32,25 +32,27 @@ from pysat.instruments.methods import general as mm_gen
 
 logger = logging.getLogger(__name__)
 
+# ----------------------------------------------------------------------------
+# Instrument attributes
+
 platform = 'sami2py'
 name = 'sami2'
-
-# dictionary of data 'tags' and corresponding description
 tags = {'': 'sami2py output file',
         'test': 'Standard output of sami2py for benchmarking'}
 inst_ids = {'': ['', 'test']}
-_test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
-_test_download = {'': {'': False,
-                       'test': True}}
 
 # specify using xarray (not using pandas)
 pandas_format = False
 
-fname = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
-supported_tags = {'': {'': fname,
-                       'test': fname}}
-list_files = functools.partial(mm_gen.list_files,
-                               supported_tags=supported_tags)
+# ----------------------------------------------------------------------------
+# Instrument test attributes
+
+_test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
+_test_download = {'': {'': False,
+                       'test': True}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
 
 
 def init(self):
@@ -81,6 +83,26 @@ def init(self):
                                 "(Version v0.2.2). Zenodo.",
                                 "http://doi.org/10.5281/zenodo.3950564"))
     logger.info(self.acknowledgements)
+    return
+
+
+def clean(self):
+    """Model data does not require cleaning
+
+    """
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use local and default pysat methods
+
+# Set the list_files routine
+fname = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
+supported_tags = {'': {'': fname, 'test': fname}}
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags)
 
 
 def load(fnames, tag=None, inst_id=None, **kwargs):
@@ -127,7 +149,10 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     """
 
     # load data
-    data = xr.open_dataset(fnames[0])
+    if len(fnames) == 1:
+        data = xr.open_dataset(fnames[0])
+    else:
+        data = xr.open_mfdataset(fnames, combine='by_coords')
 
     # add time variable for pysat compatibilty
     data['time'] = [dt.datetime(2019, 1, 1)
@@ -150,8 +175,7 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     return data, meta
 
 
-def download(date_array=None, tag=None, inst_id=None, data_path=None, user=None,
-             password=None, **kwargs):
+def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
     """Downloads sami2py data.  Currently only retrieves test data from github
 
     Parameters
@@ -167,12 +191,6 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, user=None,
         is provided by pysat. (default='')
     data_path : string
         Path to directory to download data to. (default=None)
-    user : string
-        User string input used for download. Provided by user and passed via
-        pysat. If an account is required for dowloads this routine here must
-        error if user not supplied. (default=None)
-    password : string (None)
-        Password for data download.
     **kwargs : dict
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -65,22 +65,22 @@ def init(self):
 
     """
 
-    self.meta.acknowledgments = " ".join(("This work uses the SAMI2 ionosphere",
-                                          "model written and developed by the",
-                                          "Naval Research Laboratory."))
-    self.meta.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
-                                     "Sami2 is Another Model of the Ionosphere",
-                                     "(SAMI2): A new low‐latitude ionosphere",
-                                     "model, J. Geophys. Res., 105, Pages",
-                                     "23035-23053,",
-                                     "https://doi.org/10.1029/2000JA000035,",
-                                     "2000.\n",
-                                     "Klenzing, J., Jonathon Smith, Michael",
-                                     "Hirsch, & Angeline G. Burrell. (2020,",
-                                     "July 17). sami2py/sami2py: Version 0.2.2",
-                                     "(Version v0.2.2). Zenodo.",
-                                     "http://doi.org/10.5281/zenodo.3950564"))
-    logger.info(self.meta.acknowledgments)
+    self.acknowledgements = " ".join(("This work uses the SAMI2 ionosphere",
+                                      "model written and developed by the",
+                                      "Naval Research Laboratory."))
+    self.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
+                                "Sami2 is Another Model of the Ionosphere",
+                                "(SAMI2): A new low‐latitude ionosphere",
+                                "model, J. Geophys. Res., 105, Pages",
+                                "23035-23053,",
+                                "https://doi.org/10.1029/2000JA000035,",
+                                "2000.\n",
+                                "Klenzing, J., Jonathon Smith, Michael",
+                                "Hirsch, & Angeline G. Burrell. (2020,",
+                                "July 17). sami2py/sami2py: Version 0.2.2",
+                                "(Version v0.2.2). Zenodo.",
+                                "http://doi.org/10.5281/zenodo.3950564"))
+    logger.info(self.acknowledgements)
 
 
 def load(fnames, tag=None, sat_id=None, **kwargs):
@@ -128,10 +128,12 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
 
     # load data
     data = xr.open_dataset(fnames[0])
+
     # add time variable for pysat compatibilty
     data['time'] = [dt.datetime(2019, 1, 1)
                     + dt.timedelta(seconds=int(val * 3600.0))
                     for val in data['ut'].values]
+
     # move attributes to the Meta object
     # these attributes will be trasnferred to the Instrument object
     # automatically by pysat
@@ -190,8 +192,10 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
         date = date_array[0]
         remote_url = 'https://github.com/sami2py/sami2py/'
         remote_path = 'blob/main/sami2py/tests/test_data/'
+
         # Need to tell github to show the raw data, not the webpage version
         fname = 'sami2py_output.nc?raw=true'
+
         # Use pysat-compatible name
         format_str = supported_tags[sat_id][tag]
         saved_local_fname = os.path.join(data_path,
@@ -206,4 +210,5 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
 
     else:
         warnings.warn('Downloads currently only supported for test files.')
+
     return

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -109,9 +109,9 @@ def init(self):
 
     """
 
-    self.meta.acknowledgements = ack
-    self.meta.references = "\n".join((refs))
-    logger.info(self.meta.acknowledgements)
+    self.acknowledgements = ack
+    self.references = "\n".join((refs))
+    logger.info(self.acknowledgements)
     return
 
 

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -28,73 +28,25 @@ from pysat.instruments.methods import general as mm_gen
 
 logger = logging.getLogger('pysat')
 
+# ----------------------------------------------------------------------------
+# Instrument attributes
 
 platform = 'ucar'
 name = 'tiegcm'
-
-# dictionary of data 'tags' and corresponding description
 tags = {'': 'UCAR TIE-GCM file'}
-# dictionary of satellite IDs, list of corresponding tags for each inst_ids
 inst_ids = {'': ['']}
-# good day to download test data for. Downloads aren't currently supported!
-# format is outer dictionary has inst_id as the key
-# each inst_id has a dictionary of test dates keyed by tag string
-_test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
-_test_download = {'': {'': False}}
 
 # specify using xarray (not using pandas)
 pandas_format = False
 
-fname = 'tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc'
-supported_tags = {'': {'': fname}}
-list_files = functools.partial(mm_gen.list_files,
-                               supported_tags=supported_tags)
+# ----------------------------------------------------------------------------
+# Instrument test attributes
 
-ack = " ".join(["References and information about TIEGCM are available at",
-                "https://www.hao.ucar.edu/modeling/tgcm/index.php"])
-refs = [" ".join(("Dickinson, R. E., E. C. Ridley and R. G. Roble, A",
-                  "three-dimensional general circulation model of the",
-                  "thermosphere, J. Geophys. Res., 86, 1499-1512, 1981.")),
-        " ".join(("Dickinson, R. E., E. C. Ridley and R. G. Roble,",
-                  "Thermospheric general circulation with coupled dynamics and",
-                  "composition, J. Atmos. Sci., 41, 205-219, 1984.")),
-        " ".join(("Roble, R. G., and E. C. Ridley, An auroral model for the",
-                  "NCAR thermospheric general circulation model (TGCM),",
-                  "Annales Geophys., 5A, 369-382, 1987.")),
-        " ".join(("Roble, R. G., E. C. Ridley and R. E. Dickinson, On the",
-                  "global mean structure of the thermosphere, J. Geophys.",
-                  "Res., 92, 8745-8758, 1987.")),
-        " ".join(("Roble, R. G., E. C. Ridley, A. D. Richmond and R. E.",
-                  "Dickinson, A coupled thermosphere/ionosphere general",
-                  "circulation model, Geophys. Res. Lett., 15, 1325-1328,",
-                  "1988.")),
-        " ".join(("Richmond, A. D., E. C. Ridley and R. G. Roble, A",
-                  "Thermosphere/Ionosphere General Circulation Model with",
-                  "coupled electrodynamics, Geophys. Res. Lett., 19, 601-604,",
-                  "1992.")),
-        " ".join(("Roble, R. G., and E. C. Ridley, A",
-                  "thermosphere-ionosphere-mesosphere-electrodynamics general",
-                  "circulation model (TIME-GCM): equinox solar cycle minimum",
-                  "simulations (30-500 km), Geophys. Res. Lett., 21, 417-420,",
-                  "1994.")),
-        " ".join(("Roble, R. G., Energetics of the mesosphere and",
-                  "thermosphere, AGU, Geophysical Monographs, eds. R. M.",
-                  "Johnson and T. L. Killeen, 87, 1-22, 1995.")),
-        " ".join(("Wang, W., M. Wiltberger, A. G. Burns, S. Solomon, T. L.",
-                  "Killeen, N. Maruyama, and J. Lyon, Initial results from the",
-                  "CISM coupled magnetosphere-ionosphere-thermosphere (CMIT)",
-                  "model: thermosphere ionosphere responses, J. Atmos.",
-                  "Sol.-Terr. Phys., 66, 1425-1442,",
-                  "doi:10.1016/j.jastp.2004.04.008, 2004.")),
-        " ".join(("Solomon, S. C., and L. Y. Qian, Solar extreme-ultraviolet",
-                  "irradiance for general circulation models, J. Geophys.",
-                  "Res., 110, A10306, doi:10.1029/2005JA011160, 2005.")),
-        " ".join(("Qian, L., A. G. Burns, B. A. Emery, B. Foster, G. Lu, A.",
-                  "Maute, A. D. Richmond, R. G. Roble, S. C. Solomon, and W.",
-                  "Wangm, The NCAR TIE-GCM: A community model of the coupled",
-                  "thermosphere/ionosphere system, in Modeling the",
-                  "Ionosphere-Thermosphere System, AGU Geophysical Monograph",
-                  "Series, 2014."))]
+_test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
+_test_download = {'': {'': False}}
+
+# ----------------------------------------------------------------------------
+# Instrument methods
 
 
 def init(self):
@@ -108,11 +60,77 @@ def init(self):
         This object
 
     """
+    ack = " ".join(["References and information about TIEGCM are available at",
+                    "https://www.hao.ucar.edu/modeling/tgcm/index.php"])
+    refs = [" ".join(("Dickinson, R. E., E. C. Ridley and R. G. Roble, A",
+                      "three-dimensional general circulation model of the",
+                      "thermosphere, J. Geophys. Res., 86, 1499-1512, 1981.")),
+            " ".join(("Dickinson, R. E., E. C. Ridley and R. G. Roble,",
+                      "Thermospheric general circulation with coupled",
+                      "dynamics and composition, J. Atmos. Sci., 41, 205-219,",
+                      "1984.")),
+            " ".join(("Roble, R. G., and E. C. Ridley, An auroral model for",
+                      "the NCAR thermospheric general circulation model",
+                      "(TGCM), Annales Geophys., 5A, 369-382, 1987.")),
+            " ".join(("Roble, R. G., E. C. Ridley and R. E. Dickinson, On the",
+                      "global mean structure of the thermosphere, J. Geophys.",
+                      "Res., 92, 8745-8758, 1987.")),
+            " ".join(("Roble, R. G., E. C. Ridley, A. D. Richmond and R. E.",
+                      "Dickinson, A coupled thermosphere/ionosphere general",
+                      "circulation model, Geophys. Res. Lett., 15, 1325-1328,",
+                      "1988.")),
+            " ".join(("Richmond, A. D., E. C. Ridley and R. G. Roble, A",
+                      "Thermosphere/Ionosphere General Circulation Model with",
+                      "coupled electrodynamics, Geophys. Res. Lett., 19,",
+                      "601-604, 1992.")),
+            " ".join(("Roble, R. G., and E. C. Ridley, A",
+                      "thermosphere-ionosphere-mesosphere-electrodynamics",
+                      "general circulation model (TIME-GCM): equinox solar",
+                      "cycle minimum simulations (30-500 km), Geophys. Res.",
+                      "Lett., 21, 417-420, 1994.")),
+            " ".join(("Roble, R. G., Energetics of the mesosphere and",
+                      "thermosphere, AGU, Geophysical Monographs, eds. R. M.",
+                      "Johnson and T. L. Killeen, 87, 1-22, 1995.")),
+            " ".join(("Wang, W., M. Wiltberger, A. G. Burns, S. Solomon, T. L.",
+                      "Killeen, N. Maruyama, and J. Lyon, Initial results",
+                      "from the CISM coupled magnetosphere-ionosphere-",
+                      "thermosphere (CMIT) model: thermosphere ionosphere ",
+                      "responses, J. Atmos. Sol.-Terr. Phys., 66, 1425-1442,",
+                      "doi:10.1016/j.jastp.2004.04.008, 2004.")),
+            " ".join(("Solomon, S. C., and L. Y. Qian, Solar",
+                      "extreme-ultraviolet irradiance for general circulation",
+                      "models, J. Geophys. Res., 110, A10306,",
+                      "doi:10.1029/2005JA011160, 2005.")),
+            " ".join(("Qian, L., A. G. Burns, B. A. Emery, B. Foster, G. Lu,",
+                      "A. Maute, A. D. Richmond, R. G. Roble, S. C. Solomon,",
+                      "and W. Wangm, The NCAR TIE-GCM: A community model of",
+                      "the coupled thermosphere/ionosphere system, in",
+                      "Modeling the Ionosphere-Thermosphere System, AGU",
+                      "Geophysical Monograph Series, 2014."))]
 
     self.acknowledgements = ack
     self.references = "\n".join((refs))
     logger.info(self.acknowledgements)
     return
+
+
+def clean(self):
+    """Model data does not require cleaning
+
+    """
+    return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use local and default pysat methods
+
+# Set the list_files routine
+fname = 'tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc'
+supported_tags = {'': {'': fname}}
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags)
 
 
 def load(fnames, tag=None, inst_id=None, **kwargs):
@@ -159,7 +177,11 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     """
 
     # load data
-    data = xr.open_dataset(fnames[0])
+    if len(fnames) == 1:
+        data = xr.open_dataset(fnames[0])
+    else:
+        data = xr.open_mfdataset(fnames, combine='by_coords')
+
     # move attributes to the Meta object
     # these attributes will be trasnferred to the Instrument object
     # automatically by pysat
@@ -181,14 +203,14 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     meta.grav = data['grav']
     meta.mag = data['mag']
     meta.timestep = data['timestep']
+
     # remove these variables from xarray
     data = data.drop(['p0', 'p0_model', 'grav', 'mag', 'timestep'])
 
     return data, meta
 
 
-def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
-             **kwargs):
+def download(date_array, tag, inst_id, data_path=None, **kwargs):
     """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
 
     Parameters
@@ -204,12 +226,6 @@ def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
         is provided by pysat. (default='')
     data_path : string
         Path to directory to download data to. (default=None)
-    user : string
-        User string input used for download. Provided by user and passed via
-        pysat. If an account is required for dowloads this routine here must
-        error if user not supplied. (default=None)
-    password : string
-        Password for data download. (default=None)
     **kwargs : dict
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -1,38 +1,43 @@
 import pytest
 
 import pysatModels
-from pysat.tests.instrument_test_class import generate_instrument_list
+from pysat.utils import generate_instrument_list
 from pysat.tests.instrument_test_class import InstTestClass
 
-instruments = generate_instrument_list(package=pysatModels.models)
+instruments = generate_instrument_list(inst_loc=pysatModels.models)
 
 method_list = [func for func in dir(InstTestClass)
                if callable(getattr(InstTestClass, func))]
+
 # Search tests for iteration via pytestmark, update instrument list
 for method in method_list:
     if hasattr(getattr(InstTestClass, method), 'pytestmark'):
         # Get list of names of pytestmarks
-        Nargs = len(getattr(InstTestClass, method).pytestmark)
-        names = [getattr(InstTestClass, method).pytestmark[j].name
-                 for j in range(0, Nargs)]
+        mark_name = [mod_mark.name for mod_mark
+                     in getattr(InstTestClass, method).pytestmark]
+
         # Add instruments from your library
-        if 'all_inst' in names:
-            mark = pytest.mark.parametrize("name", instruments['names'])
+        if 'all_inst' in mark_name:
+            mark = pytest.mark.parametrize("inst_name", instruments['names'])
             getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'download' in names:
-            mark = pytest.mark.parametrize("inst", instruments['download'])
+        elif 'download' in mark_name:
+            mark = pytest.mark.parametrize("inst_dict",
+                                           instruments['download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'no_download' in names:
-            mark = pytest.mark.parametrize("inst", instruments['no_download'])
+        elif 'no_download' in mark_name:
+            mark = pytest.mark.parametrize("inst_dict",
+                                           instruments['no_download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
 
 
 class TestModels(InstTestClass):
 
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
-        self.package = pysatModels.models
+        """Runs before every method to create a clean testing setup
+        """
+        self.inst_loc = pysatModels.models
 
     def teardown(self):
-        """Runs after every method to clean up previous testing."""
-        del self.package
+        """Runs after every method to clean up previous testing
+        """
+        del self.inst_loc

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -1,13 +1,13 @@
 import pytest
 import tempfile
 
-from pysat.utils import generate_instrument_list
+import pysat
 from pysat.tests.instrument_test_class import InstTestClass
 
 import pysatModels
 
 # Retrieve the lists of Model instruments and testing methods
-instruments = generate_instrument_list(inst_loc=pysatModels.models)
+instruments = pysat.utils.generate_instrument_list(inst_loc=pysatModels.models)
 method_list = [func for func in dir(InstTestClass)
                if callable(getattr(InstTestClass, func))]
 

--- a/pysatModels/tests/test_utils_match.py
+++ b/pysatModels/tests/test_utils_match.py
@@ -243,12 +243,12 @@ class TestUtilsMatchCollectInstModPairs:
 
             if mdata is not None:
                 if lout is None:
-                    glon = {'glon': (('time'),
-                                     np.linspace(*lin, mdata.dims['time']))}
+                    lin.append(mdata.dims['time'])
+                    glon = {'glon': (('time'), np.linspace(*lin))}
                     mdata = mdata.assign(glon)
                 else:
-                    mdata.coords['longitude'] = np.linspace(
-                        *lin, mdata.dims['longitude'])
+                    lin.append(mdata.dims['longitude'])
+                    mdata.coords['longitude'] = np.linspace(*lin)
             return mdata
 
         self.required_kwargs['model_load_rout'] = lon_model_load


### PR DESCRIPTION
# Description

Updates syntax for instrument tests inherited from pysat as part of pysat/pysat#552.

- End-to-end instrument tests now iterate over a list of dict objects containing info to create an instrument
- pytest.mark statements updated accordingly
- `package` renamed as `inst_loc`
- Currently failing on Travis since these updates are not in pysat develop-3, but passes locally when using the tst/inst_test_class_update branch of pysat.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

Running unit tests locally

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
