### PR TITLE
MAINT: use inst_id

### DIFF
--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -12,7 +12,7 @@ name
     'sami2'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 """
@@ -38,7 +38,7 @@ name = 'sami2'
 # dictionary of data 'tags' and corresponding description
 tags = {'': 'sami2py output file',
         'test': 'Standard output of sami2py for benchmarking'}
-sat_ids = {'': ['', 'test']}
+inst_ids = {'': ['', 'test']}
 _test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
 _test_download = {'': {'': False,
                        'test': True}}
@@ -65,25 +65,25 @@ def init(self):
 
     """
 
-    self.meta.acknowledgments = " ".join(("This work uses the SAMI2 ionosphere",
-                                          "model written and developed by the",
-                                          "Naval Research Laboratory."))
-    self.meta.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
-                                     "Sami2 is Another Model of the Ionosphere",
-                                     "(SAMI2): A new low‐latitude ionosphere",
-                                     "model, J. Geophys. Res., 105, Pages",
-                                     "23035-23053,",
-                                     "https://doi.org/10.1029/2000JA000035,",
-                                     "2000.\n",
-                                     "Klenzing, J., Jonathon Smith, Michael",
-                                     "Hirsch, & Angeline G. Burrell. (2020,",
-                                     "July 17). sami2py/sami2py: Version 0.2.2",
-                                     "(Version v0.2.2). Zenodo.",
-                                     "http://doi.org/10.5281/zenodo.3950564"))
-    logger.info(self.meta.acknowledgments)
+    self.acknowledgements = " ".join(("This work uses the SAMI2 ionosphere",
+                                      "model written and developed by the",
+                                      "Naval Research Laboratory."))
+    self.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
+                                "Sami2 is Another Model of the Ionosphere",
+                                "(SAMI2): A new low‐latitude ionosphere",
+                                "model, J. Geophys. Res., 105, Pages",
+                                "23035-23053,",
+                                "https://doi.org/10.1029/2000JA000035,",
+                                "2000.\n",
+                                "Klenzing, J., Jonathon Smith, Michael",
+                                "Hirsch, & Angeline G. Burrell. (2020,",
+                                "July 17). sami2py/sami2py: Version 0.2.2",
+                                "(Version v0.2.2). Zenodo.",
+                                "http://doi.org/10.5281/zenodo.3950564"))
+    logger.info(self.acknowledgements)
 
 
-def load(fnames, tag=None, sat_id=None, **kwargs):
+def load(fnames, tag=None, inst_id=None, **kwargs):
     """Loads sami2py data using xarray.
 
     This routine is called as needed by pysat. It is not intended
@@ -97,7 +97,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     tag : string ('')
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string ('')
+    inst_id : string ('')
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
@@ -148,7 +148,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return data, meta
 
 
-def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
+def download(date_array=None, tag=None, inst_id=None, data_path=None, user=None,
              password=None, **kwargs):
     """Downloads sami2py data.  Currently only retrieves test data from github
 
@@ -160,7 +160,7 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string
@@ -193,7 +193,7 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
         # Need to tell github to show the raw data, not the webpage version
         fname = 'sami2py_output.nc?raw=true'
         # Use pysat-compatible name
-        format_str = supported_tags[sat_id][tag]
+        format_str = supported_tags[inst_id][tag]
         saved_local_fname = os.path.join(data_path,
                                          format_str.format(year=date.year,
                                                            month=date.month,

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -12,7 +12,7 @@ name
     'tiegcm'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 """
@@ -34,11 +34,11 @@ name = 'tiegcm'
 
 # dictionary of data 'tags' and corresponding description
 tags = {'': 'UCAR TIE-GCM file'}
-# dictionary of satellite IDs, list of corresponding tags for each sat_ids
-sat_ids = {'': ['']}
+# dictionary of satellite IDs, list of corresponding tags for each inst_ids
+inst_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported!
-# format is outer dictionary has sat_id as the key
-# each sat_id has a dictionary of test dates keyed by tag string
+# format is outer dictionary has inst_id as the key
+# each inst_id has a dictionary of test dates keyed by tag string
 _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 _test_download = {'': {'': False}}
 
@@ -109,13 +109,13 @@ def init(self):
 
     """
 
-    self.meta.acknowledgements = ack
-    self.meta.references = "\n".join((refs))
-    logger.info(self.meta.acknowledgements)
+    self.acknowledgements = ack
+    self.references = "\n".join((refs))
+    logger.info(self.acknowledgements)
     return
 
 
-def load(fnames, tag=None, sat_id=None, **kwargs):
+def load(fnames, tag=None, inst_id=None, **kwargs):
     """Loads TIEGCM data using xarray.
 
     This routine is called as needed by pysat. It is not intended
@@ -129,7 +129,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     tag : string ('')
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string ('')
+    inst_id : string ('')
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
@@ -187,7 +187,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return data, meta
 
 
-def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
+def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
              **kwargs):
     """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
 
@@ -199,7 +199,7 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
+    inst_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string

--- a/pysatModels/tests/test_utils_extract.py
+++ b/pysatModels/tests/test_utils_extract.py
@@ -21,10 +21,10 @@ class TestUtilsExtractObsViewModel:
         """ Runs before every method to create a clean testing setup."""
         self.args = [pysat.Instrument(platform=str('pysat'),
                                       name=str('testing'),
-                                      sat_id='12', clean_level='clean'),
+                                      inst_id='12', clean_level='clean'),
                      pysat.Instrument(platform=str('pysat'),
                                       name=str('testing'),
-                                      sat_id='6', clean_level='clean'),
+                                      inst_id='6', clean_level='clean'),
                      ['latitude', 'longitude'], ['dummy1', 'dummy2']]
 
     def teardown(self):

--- a/pysatModels/tests/test_utils_match.py
+++ b/pysatModels/tests/test_utils_match.py
@@ -26,7 +26,7 @@ class TestUtilsMatchLoadModelXarray:
         self.filename = "%Y-%m-%d.nofile"
         self.model_kwargs = {'platform': str('pysat'),
                              'name': str('testing_xarray'),
-                             'sat_id': '12',
+                             'inst_id': '12',
                              'clean_level': 'clean'}
         self.model_inst = None
         self.xout = None
@@ -113,7 +113,7 @@ class TestUtilsMatchCollectInstModPairs:
                            dt.timedelta(days=1), self.inst]
         self.ref_col = 'dummy1'
         self.model = pysat.Instrument(platform=str('pysat'),
-                                      name=str('testmodel'), sat_id='10',
+                                      name=str('testmodel'), inst_id='10',
                                       clean_level='clean')
         self.required_kwargs = {"model_load_kwargs":
                                 {"model_inst": self.model},


### PR DESCRIPTION
# Description

Addresses pysat/pysat#473, test with pysat/pysat#556

Updates use of `sat_id` to `inst_id`.

Passing locally with the `break/inst_id` branch of pysat.  Expected to fail on Travis until pysat/pysat#556 is merged.

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Try importing any instrument with the `break/inst_id` branch of pysat.  Pysat will only load the instrument if this is configured properly.

**Test Configuration**:
* Operating system: Mac OS X 10.15.6
* Version number: python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
