### PR TITLE
ENH: Load multiple days

### DIFF
--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -127,23 +127,12 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     """
 
     # load data
-    data = xr.open_dataset(fnames[0])
+    data, meta = pysat.utils.load_netcdf4(fnames, pandas_format=False)
+
     # add time variable for pysat compatibilty
     data['time'] = [dt.datetime(2019, 1, 1)
                     + dt.timedelta(seconds=int(val * 3600.0))
                     for val in data['ut'].values]
-    # move attributes to the Meta object
-    # these attributes will be trasnferred to the Instrument object
-    # automatically by pysat
-    meta = pysat.Meta()
-    for attr in data.attrs:
-        setattr(meta, attr[0], attr[1])
-    data.attrs = []
-
-    # fill Meta object with variable information
-    for key in data.variables.keys():
-        attrs = data.variables[key].attrs
-        meta[key] = attrs
 
     return data, meta
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -66,8 +66,8 @@ def init(self):
     """
 
     self.acknowledgements = " ".join(("This work uses the SAMI2 ionosphere",
-                                     "model written and developed by the",
-                                     "Naval Research Laboratory."))
+                                      "model written and developed by the",
+                                      "Naval Research Laboratory."))
     self.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
                                 "Sami2 is Another Model of the Ionosphere",
                                 "(SAMI2): A new low‐latitude ionosphere",

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -69,17 +69,17 @@ def init(self):
                                      "model written and developed by the",
                                      "Naval Research Laboratory."))
     self.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
-                                     "Sami2 is Another Model of the Ionosphere",
-                                     "(SAMI2): A new low‐latitude ionosphere",
-                                     "model, J. Geophys. Res., 105, Pages",
-                                     "23035-23053,",
-                                     "https://doi.org/10.1029/2000JA000035,",
-                                     "2000.\n",
-                                     "Klenzing, J., Jonathon Smith, Michael",
-                                     "Hirsch, & Angeline G. Burrell. (2020,",
-                                     "July 17). sami2py/sami2py: Version 0.2.2",
-                                     "(Version v0.2.2). Zenodo.",
-                                     "http://doi.org/10.5281/zenodo.3950564"))
+                                "Sami2 is Another Model of the Ionosphere",
+                                "(SAMI2): A new low‐latitude ionosphere",
+                                "model, J. Geophys. Res., 105, Pages",
+                                "23035-23053,",
+                                "https://doi.org/10.1029/2000JA000035,",
+                                "2000.\n",
+                                "Klenzing, J., Jonathon Smith, Michael",
+                                "Hirsch, & Angeline G. Burrell. (2020,",
+                                "July 17). sami2py/sami2py: Version 0.2.2",
+                                "(Version v0.2.2). Zenodo.",
+                                "http://doi.org/10.5281/zenodo.3950564"))
     logger.info(self.acknowledgements)
 
     return

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -12,7 +12,7 @@ name
     'sami2'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 """
@@ -38,7 +38,7 @@ name = 'sami2'
 # dictionary of data 'tags' and corresponding description
 tags = {'': 'sami2py output file',
         'test': 'Standard output of sami2py for benchmarking'}
-sat_ids = {'': ['', 'test']}
+inst_ids = {'': ['', 'test']}
 _test_dates = {'': {tag: dt.datetime(2019, 1, 1) for tag in tags.keys()}}
 _test_download = {'': {'': False,
                        'test': True}}
@@ -65,10 +65,10 @@ def init(self):
 
     """
 
-    self.meta.acknowledgments = " ".join(("This work uses the SAMI2 ionosphere",
-                                          "model written and developed by the",
-                                          "Naval Research Laboratory."))
-    self.meta.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
+    self.acknowledgements = " ".join(("This work uses the SAMI2 ionosphere",
+                                     "model written and developed by the",
+                                     "Naval Research Laboratory."))
+    self.references = " ".join(("Huba, J.D., G. Joyce, and J.A. Fedder,",
                                      "Sami2 is Another Model of the Ionosphere",
                                      "(SAMI2): A new low‐latitude ionosphere",
                                      "model, J. Geophys. Res., 105, Pages",
@@ -80,10 +80,38 @@ def init(self):
                                      "July 17). sami2py/sami2py: Version 0.2.2",
                                      "(Version v0.2.2). Zenodo.",
                                      "http://doi.org/10.5281/zenodo.3950564"))
-    logger.info(self.meta.acknowledgments)
+    logger.info(self.acknowledgements)
+
+    return
 
 
-def load(fnames, tag=None, sat_id=None, **kwargs):
+# Required method
+def clean(self):
+    """Method to return SAMI data cleaned to the specified level
+
+    Cleaning level is specified in inst.clean_level and pysat
+    will accept user input for several strings. The clean_level is
+    specified at instantiation of the Instrument object, though it may be
+    updated to a more stringent level and re-applied after instantiation.
+    The clean method is applied after default every time data is loaded.
+
+    Note
+    ----
+    'clean' All parameters should be good, suitable for statistical and
+            case studies
+    'dusty' All paramers should generally be good though same may
+            not be great
+    'dirty' There are data areas that have issues, data should be used
+            with caution
+    'none'  No cleaning applied, routine not called in this case.
+
+    """
+
+    logger.info('Cleaning not supported for SAMI')
+    return
+
+
+def load(fnames, tag=None, inst_id=None, **kwargs):
     """Loads sami2py data using xarray.
 
     This routine is called as needed by pysat. It is not intended
@@ -97,8 +125,8 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     tag : string ('')
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string ('')
-        Satellite ID used to identify particular data set to be loaded.
+    inst_id : string ('')
+        Instrument ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
         Passthrough for additional keyword arguments specified when
@@ -137,7 +165,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return data, meta
 
 
-def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
+def download(date_array=None, tag=None, inst_id=None, data_path=None, user=None,
              password=None, **kwargs):
     """Downloads sami2py data.  Currently only retrieves test data from github
 
@@ -149,8 +177,8 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
-        Satellite ID string identifier used for particular dataset. This input
+    inst_id : string
+        Instrument ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string
         Path to directory to download data to. (default=None)
@@ -182,7 +210,7 @@ def download(date_array=None, tag=None, sat_id=None, data_path=None, user=None,
         # Need to tell github to show the raw data, not the webpage version
         fname = 'sami2py_output.nc?raw=true'
         # Use pysat-compatible name
-        format_str = supported_tags[sat_id][tag]
+        format_str = supported_tags[inst_id][tag]
         saved_local_fname = os.path.join(data_path,
                                          format_str.format(year=date.year,
                                                            month=date.month,

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -24,8 +24,6 @@ import os
 import requests
 import warnings
 
-import xarray as xr
-
 import pysat
 from pysat.instruments.methods import general as mm_gen
 
@@ -86,25 +84,6 @@ def init(self):
     return
 
 
-def clean(self):
-    """Model data does not require cleaning
-
-    """
-    return
-
-
-# ----------------------------------------------------------------------------
-# Instrument functions
-#
-# Use local and default pysat methods
-
-# Set the list_files routine
-fname = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
-supported_tags = {'': {'': fname, 'test': fname}}
-list_files = functools.partial(mm_gen.list_files,
-                               supported_tags=supported_tags)
-
-
 # Required method
 def clean(self):
     """Method to return SAMI data cleaned to the specified level
@@ -130,6 +109,18 @@ def clean(self):
     logger.info('Cleaning not supported for SAMI')
 
     return
+
+
+# ----------------------------------------------------------------------------
+# Instrument functions
+#
+# Use local and default pysat methods
+
+# Set the list_files routine
+fname = 'sami2py_output_{year:04d}-{month:02d}-{day:02d}.nc'
+supported_tags = {'': {'': fname, 'test': fname}}
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags)
 
 
 def load(fnames, tag=None, inst_id=None, **kwargs):

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -104,8 +104,6 @@ supported_tags = {'': {'': fname, 'test': fname}}
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
-    return
-
 
 # Required method
 def clean(self):

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -12,7 +12,7 @@ name
     'tiegcm'
 tag
     None supported
-sat_id
+inst_id
     None supported
 
 """
@@ -34,11 +34,11 @@ name = 'tiegcm'
 
 # dictionary of data 'tags' and corresponding description
 tags = {'': 'UCAR TIE-GCM file'}
-# dictionary of satellite IDs, list of corresponding tags for each sat_ids
-sat_ids = {'': ['']}
+# dictionary of satellite IDs, list of corresponding tags for each inst_ids
+inst_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported!
-# format is outer dictionary has sat_id as the key
-# each sat_id has a dictionary of test dates keyed by tag string
+# format is outer dictionary has inst_id as the key
+# each inst_id has a dictionary of test dates keyed by tag string
 _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 _test_download = {'': {'': False}}
 
@@ -109,13 +109,39 @@ def init(self):
 
     """
 
-    self.meta.acknowledgements = ack
-    self.meta.references = "\n".join((refs))
-    logger.info(self.meta.acknowledgements)
+    self.acknowledgements = ack
+    self.references = "\n".join((refs))
+    logger.info(self.acknowledgements)
     return
 
 
-def load(fnames, tag=None, sat_id=None, **kwargs):
+# Required method
+def clean(self):
+    """Method to return UCER/TIEGCM data cleaned to the specified level
+
+    Cleaning level is specified in inst.clean_level and pysat
+    will accept user input for several strings. The clean_level is
+    specified at instantiation of the Instrument object, though it may be
+    updated to a more stringent level and re-applied after instantiation.
+    The clean method is applied after default every time data is loaded.
+
+    Note
+    ----
+    'clean' All parameters should be good, suitable for statistical and
+            case studies
+    'dusty' All paramers should generally be good though same may
+            not be great
+    'dirty' There are data areas that have issues, data should be used
+            with caution
+    'none'  No cleaning applied, routine not called in this case.
+
+    """
+
+    logger.info('Cleaning not supported for TIEGCM')
+    return
+
+
+def load(fnames, tag=None, inst_id=None, **kwargs):
     """Loads TIEGCM data using xarray.
 
     This routine is called as needed by pysat. It is not intended
@@ -129,8 +155,8 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     tag : string ('')
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    sat_id : string ('')
-        Satellite ID used to identify particular data set to be loaded.
+    inst_id : string ('')
+        Instrument ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
     **kwargs : extra keywords
         Passthrough for additional keyword arguments specified when
@@ -175,7 +201,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return data, meta
 
 
-def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
+def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
              **kwargs):
     """Placeholder for UCAR TIEGCM downloads. Doesn't do anything.
 
@@ -187,8 +213,8 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
     tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    sat_id : string
-        Satellite ID string identifier used for particular dataset. This input
+    inst_id : string
+        Instrument ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
     data_path : string
         Path to directory to download data to. (default=None)

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -158,20 +158,8 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
 
     """
 
-    # load data
-    data = xr.open_dataset(fnames[0])
-    # move attributes to the Meta object
-    # these attributes will be trasnferred to the Instrument object
-    # automatically by pysat
-    meta = pysat.Meta()
-    for attr in data.attrs:
-        setattr(meta, attr[0], attr[1])
-    data.attrs = []
 
-    # fill Meta object with variable information
-    for key in data.variables.keys():
-        attrs = data.variables[key].attrs
-        meta[key] = attrs
+    data, meta = pysat.utils.load_netcdf4(fnames, pandas_format=False)
 
     # move misc parameters from xarray to the Instrument object via Meta
     # doing this after the meta ensures all metadata is still kept

--- a/pysatModels/models/ucar_tiegcm.py
+++ b/pysatModels/models/ucar_tiegcm.py
@@ -22,7 +22,6 @@ import functools
 import logging
 import warnings
 
-import xarray as xr
 import pysat
 from pysat.instruments.methods import general as mm_gen
 
@@ -144,6 +143,7 @@ def clean(self):
 #
 # Use local and default pysat methods
 
+
 # Set the list_files routine
 fname = 'tiegcm_icon_merg2.0_totTgcm.s_{day:03d}_{year:4d}.nc'
 supported_tags = {'': {'': fname}}
@@ -193,7 +193,6 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
         inst.load(2019, 1)
 
     """
-
 
     data, meta = pysat.utils.load_netcdf4(fnames, pandas_format=False)
 


### PR DESCRIPTION
# Description

Addresses #(issue)

Adds support for loading multiple filenames within `.load` methods for SAMI and TIEGCM.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Tested locally by registering pysatModels.models and loading a UCAR-TIEGCM file.

**Test Configuration**:
* macOS Catalina 
* 10.15.4

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
