### PR TITLE
MAINT/BUG: Update requirements, NEP29

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         numpy_ver: [latest]
         include:
           - python-version: "3.7"
-            numpy_ver: "1.17"
+            numpy_ver: "1.18"
             os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ the Space Physics community.  This module officially supports Python 3.6+.
 | Common modules | Community modules |
 | -------------- | ----------------- |
 | numpy          | pysat             |
-| scipy          | pyForecastTools   |
-| pandas         |                   |
+| pandas         | pyForecastTools   |
+| requests       |                   |
+| scipy          |                   |
 | xarray         |                   |
 
 ## Installation

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,10 +23,11 @@ the Space Physics community.  This module officially supports Python 3.6+.
  ============== =================
  Common modules Community modules
  ============== =================
-  numpy         pysat             
-  scipy         pyForecastTools   
-  pandas                             
-  xarray              
+  numpy         pysat
+  pandas        pyForecastTools
+  requests
+  scipy
+  xarray
  ============== =================
 
 
@@ -38,7 +39,7 @@ Installation Options
 1. Clone the git repository
 ::
 
-   
+
    git clone https://github.com/pysat/pysatModels.git
 
 
@@ -48,13 +49,13 @@ Installation Options
 
    A. Install on the system (root privileges required)::
 
-	
+
         sudo python3 setup.py install
    B. Install at the user level::
 
-	
-        python3 setup.py install --user  
+
+        python3 setup.py install --user
    C. Install with the intent to develop locally::
 
-	
+
         python3 setup.py develop --user

--- a/pysatModels/tests/test_utils_match.py
+++ b/pysatModels/tests/test_utils_match.py
@@ -24,7 +24,7 @@ class TestUtilsMatchLoadModelXarray():
         self.filename = "%Y-%m-%d.nofile"
         self.model_kwargs = {'platform': str('pysat'),
                              'name': str('testing_xarray'),
-                             'inst_id': '12',
+                             'num_samples': 12,
                              'clean_level': 'clean'}
         self.model_inst = None
         self.xout = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy
 pandas
 pyForecastTools
 pysat >= 3.0.0
+requests
 scipy
 xarray


### PR DESCRIPTION
# Description

Addresses #85

- Adds `requests` to list of requirements and in documentation.
- Updates NEP29 version of numpy for testing to 1.18.  This will prevent issues with pandas in the future, since they have dropped support for 1.17.0.
- Bug fix: use num_samples=12 rather than inst_id='12'.  This may be superseded by #83, but is fixed here so tests pass.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Via Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
