### PR TITLE
BUG: update windows bugs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r test_requirements.txt
         pip install -r requirements.txt
-        # Temporary manual install of pysat
-        pip install pysat
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r test_requirements.txt
         pip install -r requirements.txt
-        
-        # Temporary install commands to test RC
-        pip install -r pysat_requirements.txt
-        pip install -i https://test.pypi.org/simple/ pysat==3.0.1rc1
 
     - name: Install NEP29 dependencies
       if: ${{ matrix.numpy_ver != 'latest'}}

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -213,6 +213,7 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                 if not os.path.isfile(saved_local_fname):
                     with open(saved_local_fname, 'wb') as open_f:
                         open_f.write(req.content)
+                    open_f.close()
             else:
                 warnings.warn('Unable to find remote file: {:}'.format(
                     remote_path))

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -214,8 +214,8 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                     with open(saved_local_fname, 'wb') as open_f:
                         open_f.write(req.content)
             else:
-                warnings.warn('Unable to find remote file: {:}'.format(
-                    remote_path))
+                warnings.warn(' '.join(('Unable to find remote file:',
+                                        remote_path))))
     else:
         warnings.warn('Downloads currently only supported for test files.')
 

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -159,7 +159,7 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     # returning an xarray.Dataset
     data, meta = pysat.utils.load_netcdf4(fnames, epoch_name='time',
                                           pandas_format=False)
-    # Manually close link to file
+    # Manually close link to file.
     data.close()
 
     return data, meta

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -159,6 +159,9 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     # returning an xarray.Dataset
     data, meta = pysat.utils.load_netcdf4(fnames, epoch_name='time',
                                           pandas_format=False)
+    # Manually close link to file
+    data.close()
+
     return data, meta
 
 

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -215,7 +215,7 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                         open_f.write(req.content)
             else:
                 warnings.warn(' '.join(('Unable to find remote file:',
-                                        remote_path))))
+                                        remote_path)))
     else:
         warnings.warn('Downloads currently only supported for test files.')
 

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -213,15 +213,10 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                 if not os.path.isfile(saved_local_fname):
                     with open(saved_local_fname, 'wb') as open_f:
                         open_f.write(req.content)
-                    open_f.close()
             else:
                 warnings.warn('Unable to find remote file: {:}'.format(
                     remote_path))
     else:
-        saved_local_fname = os.path.join(data_path, 'empty_file.txt')
-        with open(saved_local_fname, 'w') as open_f:
-            open_f.write(' ')
-
         warnings.warn('Downloads currently only supported for test files.')
 
     return

--- a/pysatModels/models/pydineof_dineof.py
+++ b/pysatModels/models/pydineof_dineof.py
@@ -157,8 +157,9 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
 
     # netCDF4 files were produced by xarray
     # returning an xarray.Dataset
-    return pysat.utils.load_netcdf4(fnames, epoch_name='time',
-                                    pandas_format=False)
+    data, meta = pysat.utils.load_netcdf4(fnames, epoch_name='time',
+                                          pandas_format=False)
+    return data, meta
 
 
 def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -200,7 +200,6 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
             if not os.path.isfile(saved_local_fname):
                 with open(saved_local_fname, 'wb') as open_f:
                     open_f.write(req.content)
-                open_f.close()
         else:
             warnings.warn('Unable to find remote file: {:}'.format(remote_path))
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -197,8 +197,9 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                                 fname))
         req = requests.get(remote_path)
         if req.status_code != 404:
-            fobj = open(saved_local_fname, 'wb').write(req.content)
-            fobj.close()
+            if not os.path.isfile(saved_local_fname):
+                with open(saved_local_fname, 'wb') as open_f:
+                    open_f.write(req.content)
         else:
             warnings.warn('Unable to find remote file: {:}'.format(remote_path))
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -197,7 +197,8 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                                 fname))
         req = requests.get(remote_path)
         if req.status_code != 404:
-            open(saved_local_fname, 'wb').write(req.content)
+            fobj = open(saved_local_fname, 'wb').write(req.content)
+            fobj.close()
         else:
             warnings.warn('Unable to find remote file: {:}'.format(remote_path))
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -144,6 +144,8 @@ def load(fnames, tag=None, inst_id=None, **kwargs):
     data['time'] = [dt.datetime(2019, 1, 1)
                     + dt.timedelta(seconds=int(val * 3600.0))
                     for val in data['ut'].values]
+    # Manually close link to file
+    data.close()
 
     return data, meta
 

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -195,13 +195,13 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                                                            day=date.day))
         remote_path = '/'.join((remote_url.strip('/'), remote_path.strip('/'),
                                 fname))
-        req = requests.get(remote_path)
-        if req.status_code != 404:
-            if not os.path.isfile(saved_local_fname):
+        with requests.get(remote_path) as req:
+            if req.status_code != 404:
                 with open(saved_local_fname, 'wb') as open_f:
                     open_f.write(req.content)
-        else:
-            warnings.warn('Unable to find remote file: {:}'.format(remote_path))
+            else:
+                warnings.warn(' '.join(('Unable to find remote file:',
+                                        remote_path))))
 
     else:
         warnings.warn('Downloads currently only supported for test files.')

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -201,7 +201,7 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
                     open_f.write(req.content)
             else:
                 warnings.warn(' '.join(('Unable to find remote file:',
-                                        remote_path))))
+                                        remote_path)))
 
     else:
         warnings.warn('Downloads currently only supported for test files.')

--- a/pysatModels/models/sami2py_sami2.py
+++ b/pysatModels/models/sami2py_sami2.py
@@ -200,6 +200,7 @@ def download(date_array=None, tag=None, inst_id=None, data_path=None, **kwargs):
             if not os.path.isfile(saved_local_fname):
                 with open(saved_local_fname, 'wb') as open_f:
                     open_f.write(req.content)
+                open_f.close()
         else:
             warnings.warn('Unable to find remote file: {:}'.format(remote_path))
 

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -6,6 +6,9 @@ from pysat.tests.instrument_test_class import InstTestClass
 
 import pysatModels
 
+# Test code - remove methods
+del InstTestClass.test_load
+
 # Retrieve the lists of Model instruments and testing methods
 instruments = pysat.utils.generate_instrument_list(inst_loc=pysatModels.models)
 method_list = [func for func in dir(InstTestClass)

--- a/pysatModels/tests/test_models.py
+++ b/pysatModels/tests/test_models.py
@@ -6,9 +6,6 @@ from pysat.tests.instrument_test_class import InstTestClass
 
 import pysatModels
 
-# Test code - remove methods
-del InstTestClass.test_load
-
 # Retrieve the lists of Model instruments and testing methods
 instruments = pysat.utils.generate_instrument_list(inst_loc=pysatModels.models)
 method_list = [func for func in dir(InstTestClass)

--- a/pysat_requirements.txt
+++ b/pysat_requirements.txt
@@ -1,8 +1,0 @@
-dask
-netCDF4<1.5.7
-numpy>=1.12
-pandas>=0.23
-portalocker
-scipy
-toolz
-xarray


### PR DESCRIPTION
# Description

Addresses #89

Updates the new main.yml tests for windows compliance post pysat 3.0.1 release.

A file link was left open after loading files, which messed with the ability to delete the tempdir on windows systems.  Closing the file after load solves the issue.  In the long term, changes will be needed at pysat. See pysat/pysat#887

