### PR TITLE
Icon fixes

### DIFF
--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -6,6 +6,7 @@
 """Routines to extract observational-style data from model output."""
 
 import numpy as np
+import re
 import scipy.interpolate as interpolate
 
 import pandas as pds
@@ -317,7 +318,8 @@ def instrument_view_through_model(inst, model, inst_name, mod_name,
         # Some units may have extra information (e.g., 'degrees North').
         # Use only the actual units in the scaling function.  These are assumed
         # to come first.
-        long_units = inst.meta[iname, inst.meta.labels.units].split()[0]
+        long_units = re.split('\W+|_',
+                              inst.meta[iname, inst.meta.labels.units])[0]
         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
     del_list = list()
@@ -483,7 +485,8 @@ def instrument_view_irregular_model(inst, model, inst_name, mod_name,
         # Some units may have extra information (e.g., 'degrees North').
         # Use only the actual units in the scaling function.  These are assumed
         # to come first.
-        long_units = inst.meta[iname, inst.meta.labels.units].split()[0]
+        long_units = re.split('\W+|_',
+                              inst.meta[iname, inst.meta.labels.units])[0]
         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
     # First, model locations for interpolation (regulargrid)
@@ -680,7 +683,8 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
         # Some units may have extra information (e.g., 'degrees North').
         # Use only the actual units in the scaling function.  These are assumed
         # to come first.
-        long_units = inst.meta[iname, inst.meta.labels.units].split()[0]
+        long_units = re.split('\W+|_',
+                              inst.meta[iname, inst.meta.labels.units])[0]
         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
     # Determine the model time resolution

--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -105,7 +105,7 @@ def instrument_altitude_to_model_pressure(inst, model, inst_name, mod_name,
         if iname not in inst.data.keys():
             raise ValueError(''.join(['Unknown instrument location index ',
                                       '{:}'.format(iname)]))
-        # altitude variable check
+        # Altitude variable check
         if iname == inst_alt:
             alt_scale = pyutils.scale_units(
                 mod_alt_units, inst.meta[iname, inst.meta.labels.units])
@@ -313,8 +313,12 @@ def instrument_view_through_model(inst, model, inst_name, mod_name,
         if iname not in inst.data.keys():
             raise ValueError(''.join(['Unknown instrument location index ',
                                       '{:}'.format(iname)]))
-        inst_scale[i] = pyutils.scale_units(
-            mod_units[i], inst.meta[iname, inst.meta.labels.units])
+
+        # Some units may have extra information (e.g., 'degrees North').
+        # Use only the actual units in the scaling function.  These are assumed
+        # to come first.
+        long_units = inst.meta[iname, inst.meta.labels.units].split()[0]
+        inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
     del_list = list()
     keep_list = list()
@@ -476,8 +480,11 @@ def instrument_view_irregular_model(inst, model, inst_name, mod_name,
             raise ValueError(''.join(['Unknown instrument location index ',
                                       '{:}'.format(iname)]))
 
-        inst_scale[i] = pyutils.scale_units(
-            mod_units[i], inst.meta[iname, inst.meta.labels.units])
+        # Some units may have extra information (e.g., 'degrees North').
+        # Use only the actual units in the scaling function.  These are assumed
+        # to come first.
+        long_units = inst.meta[iname, inst.meta.labels.units].split()[0]
+        inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
     # First, model locations for interpolation (regulargrid)
     coords = [model[dim].values / temp_scale
@@ -669,8 +676,12 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
             raise ValueError(''.join(['Unknown instrument location index ',
                                       '{:} '.format(iname),
                                       '(should not be epoch time)']))
-        inst_scale[i] = pyutils.scale_units(
-            mod_units[i], inst.meta[iname, inst.meta.labels.units])
+
+        # Some units may have extra information (e.g., 'degrees North').
+        # Use only the actual units in the scaling function.  These are assumed
+        # to come first.
+        long_units = inst.meta[iname, inst.meta.labels.units].split()[0]
+        inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
     # Determine the model time resolution
     if mod_datetime_name in model.data_vars:

--- a/pysatModels/utils/extract.py
+++ b/pysatModels/utils/extract.py
@@ -245,6 +245,14 @@ def instrument_view_through_model(inst, model, inst_name, mod_name,
     this does also yield an exponential variation along the horizontal
     directions as well.
 
+    Expects units strings to have the units as the first word, if a long
+    description is provided (e.g., 'degrees', 'degrees North', or 'deg_N' and
+    not 'geographic North degrees')
+
+    See Also
+    --------
+    pysat.utils.scale_units
+
     """
 
     # Ensure the coordinate and data variable names are array-like
@@ -318,7 +326,7 @@ def instrument_view_through_model(inst, model, inst_name, mod_name,
         # Some units may have extra information (e.g., 'degrees North').
         # Use only the actual units in the scaling function.  These are assumed
         # to come first.
-        long_units = re.split('\W+|_',
+        long_units = re.split(r"\W+|_",
                               inst.meta[iname, inst.meta.labels.units])[0]
         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
@@ -430,6 +438,17 @@ def instrument_view_irregular_model(inst, model, inst_name, mod_name,
     interp_data.keys() : dict_keys
         Keys of modelled data added to the instrument
 
+
+    Notes
+    -----
+    Expects units strings to have the units as the first word, if a long
+    description is provided (e.g., 'degrees', 'degrees North', or 'deg_N' and
+    not 'geographic North degrees')
+
+    See Also
+    --------
+    pysat.utils.scale_units
+
     """
 
     # Ensure the inputs are array-like
@@ -485,7 +504,7 @@ def instrument_view_irregular_model(inst, model, inst_name, mod_name,
         # Some units may have extra information (e.g., 'degrees North').
         # Use only the actual units in the scaling function.  These are assumed
         # to come first.
-        long_units = re.split('\W+|_',
+        long_units = re.split(r"\W+|_",
                               inst.meta[iname, inst.meta.labels.units])[0]
         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 
@@ -683,7 +702,7 @@ def extract_modelled_observations(inst, model, inst_name, mod_name,
         # Some units may have extra information (e.g., 'degrees North').
         # Use only the actual units in the scaling function.  These are assumed
         # to come first.
-        long_units = re.split('\W+|_',
+        long_units = re.split(r"\W+|_",
                               inst.meta[iname, inst.meta.labels.units])[0]
         inst_scale[i] = pyutils.scale_units(mod_units[i], long_units)
 

--- a/pysatModels/utils/match.py
+++ b/pysatModels/utils/match.py
@@ -217,7 +217,7 @@ def collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs=None,
             if inst.empty or inst.index[-1] < istart:
                 inst.load(date=istart)
 
-            if not inst.empty and inst.index[0] >= istart:
+            if not inst.empty and np.any(inst.index >= istart):
                 added_names = extract.extract_modelled_observations(
                     inst=inst, model=mdata, inst_name=inst_name,
                     mod_name=mod_name, mod_datetime_name=mod_datetime_name,


### PR DESCRIPTION
# Description

Changes necessary to perform evaluations with ICON data.  ICON revealed the following issues:

1) files may start just before the start day
2) units don't conform to `pysat.utils.scale_units` standards (e.g., 'degrees North' instead of 'degrees')

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran a SAMI3-ICON topside ion density validation.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.9
* Any details about your local setup that are relevant: full success requires changes implemented in 'add_io_utils' branch on pysat.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
